### PR TITLE
examples: perf and simplify mark-recapture

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ serde_bytes = "0.11.5"
 thiserror = "1.0.49"
 crc = "3.0.1"
 sha1_smol = "1.0.0"
-flume = { version = "0.11.0", features = [], default-features = false}
+flume = { version = "0.11.0", features = [], default-features = false }
 ed25519-dalek = "2.1.0"
 bytes = "1.5.0"
 tracing = "0.1"
@@ -29,6 +29,8 @@ document-features = "0.2.10"
 clap = { version = "4.4.8", features = ["derive"] }
 futures = "0.3.29"
 tracing-subscriber = "0.3"
+rayon = "1.5"
+dashmap = "6.1"
 
 [features]
 ## Enable [Dht::as_async()] to use [async_dht::AsyncDht]


### PR DESCRIPTION
- [x] Improve perf by paralleling lookups, default `batch_size` is `16` . It does achieve about 16 times the performance, quality of estimate seems unnafected.
- [x] Simplify setup and hyper-params by using continuous sampling.
- [x] Continuously log to console current node count estimate and std-error.

With default config (looking for minimum 10K overlapping nodes) it takes about ~2.5 hours. Results:
```
Final Estimate:
Estimated DHT Size: 12.0M nodes
95% Confidence Interval: 11.8M - 12.3M nodes
Standard Error: 116.9K nodes
```