### PR TITLE
feat: make MutableItem de/serializable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ crc = "3.2.1"
 sha1_smol = "1.0.1"
 flume = { version = "0.11.1", features = [], default-features = false }
 ed25519-dalek = "2.1.1"
-bytes = "1.9.0"
+bytes = { version = "1.9.0", features = ["serde"] }
 tracing = "0.1"
 lru = { version = "0.12.5", default-features = false }
 document-features = "0.2.10"

--- a/src/common/id.rs
+++ b/src/common/id.rs
@@ -1,6 +1,7 @@
 //! Kademlia node Id or a lookup target
 use crc::{Crc, CRC_32_ISCSI};
 use rand::Rng;
+use serde::{Deserialize, Serialize};
 use std::convert::TryInto;
 use std::{
     fmt::{self, Debug, Display, Formatter},
@@ -15,7 +16,7 @@ pub const MAX_DISTANCE: u8 = ID_SIZE as u8 * 8;
 const IPV4_MASK: u32 = 0x030f3fff;
 const CASTAGNOLI: Crc<u32> = Crc::<u32>::new(&CRC_32_ISCSI);
 
-#[derive(Clone, Copy, PartialEq, Ord, PartialOrd, Eq, Hash)]
+#[derive(Clone, Copy, PartialEq, Ord, PartialOrd, Eq, Hash, Serialize, Deserialize)]
 /// Kademlia node Id or a lookup target
 pub struct Id([u8; ID_SIZE]);
 

--- a/src/common/mutable.rs
+++ b/src/common/mutable.rs
@@ -2,12 +2,13 @@
 
 use bytes::Bytes;
 use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
+use serde::{Deserialize, Serialize};
 use sha1_smol::Sha1;
 use std::convert::TryFrom;
 
 use crate::Id;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 /// [Bep_0044](https://www.bittorrent.org/beps/bep_0044.html)'s Mutable item.
 pub struct MutableItem {
     /// hash of the key and optional salt
@@ -19,6 +20,7 @@ pub struct MutableItem {
     /// mutable value
     value: Bytes,
     /// ed25519 signature
+    #[serde(with = "serde_bytes")]
     signature: [u8; 64],
     /// Optional salt
     salt: Option<Bytes>,


### PR DESCRIPTION
I have this idea of creating the `MutableItem` with my private key on an offline device, serializing it to a file on a USB key, and then using an online device to push it into the DHT, so as to keep the private key offline.  This requires serde on the MutableItem.