### PR TITLE
feat: add get_socket() function to Dht

### DIFF
--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -887,6 +887,10 @@ impl Rpc {
             }
         };
     }
+    
+    pub(crate) fn get_socket(&self) -> &KrpcSocket {
+        &self.socket
+    }
 }
 
 struct CachedIterativeQuery {

--- a/src/rpc/socket.rs
+++ b/src/rpc/socket.rs
@@ -307,6 +307,10 @@ impl KrpcSocket {
         trace!(context = "socket_message_sending", message = ?message);
         Ok(())
     }
+
+    pub fn get_socket(&self) -> &UdpSocket {
+        &self.socket
+    }
 }
 
 #[derive(thiserror::Error, Debug)]


### PR DESCRIPTION
I have added get_socket() function to be able to reuse the same UdpSocket in another udp server.

To get the socket you can make : 

```rust
        let mut dht = Dht::server().unwrap();
        let socket = dht.get_socket();
```

sorry my english not so good