### PR TITLE
Feature gate `Testnet` new_async + Dep bump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/pubky/mainline"
 exclude = ["/docs/*", "/examples/*"]
 
 [dependencies]
-getrandom = "0.2"
+getrandom = "0.3"
 serde_bencode = "^0.2.4"
 serde = { version = "1.0.217", features = ["derive"] }
 serde_bytes = "0.11.15"
@@ -21,7 +21,7 @@ crc = "3.2.1"
 sha1_smol = "1.0.1"
 ed25519-dalek = "2.1.1"
 tracing = "0.1"
-lru = { version = "0.13.0", default-features = false }
+lru = { version = "0.16.0", default-features = false }
 dyn-clone = "1.0.18"
 
 document-features = "0.2.10"

--- a/src/common/id.rs
+++ b/src/common/id.rs
@@ -1,6 +1,5 @@
 //! Kademlia node Id or a lookup target
 use crc::{Crc, CRC_32_ISCSI};
-use getrandom::getrandom;
 use serde::{Deserialize, Serialize};
 use std::convert::TryInto;
 use std::{
@@ -24,8 +23,7 @@ impl Id {
     /// Generate a random Id
     pub fn random() -> Id {
         let mut bytes: [u8; 20] = [0; 20];
-        getrandom::getrandom(&mut bytes).expect("getrandom");
-
+        getrandom::fill(&mut bytes).expect("getrandom");
         Id(bytes)
     }
 
@@ -99,7 +97,7 @@ impl Id {
     /// Create a new Id from an Ipv4 address according to [BEP_0042](http://bittorrent.org/beps/bep_0042.html).
     pub fn from_ipv4(ipv4: Ipv4Addr) -> Id {
         let mut bytes = [0_u8; 21];
-        getrandom(&mut bytes).expect("getrandom");
+        getrandom::fill(&mut bytes).expect("getrandom");
 
         from_ipv4_and_r(bytes[1..].try_into().expect("infallible"), ipv4, bytes[0])
     }

--- a/src/dht.rs
+++ b/src/dht.rs
@@ -656,6 +656,7 @@ impl Testnet {
         Ok(testnet)
     }
 
+    #[cfg(feature = "async")]
     /// Similar to [Self::new] but awaits all nodes to bootstrap instead of blocking.
     pub async fn new_async(count: usize) -> Result<Testnet, std::io::Error> {
         let testnet = Testnet::new_inner(count)?;

--- a/src/rpc/server/peers.rs
+++ b/src/rpc/server/peers.rs
@@ -4,7 +4,6 @@ use std::{net::SocketAddrV4, num::NonZeroUsize};
 
 use crate::common::Id;
 
-use getrandom::getrandom;
 use lru::LruCache;
 
 const CHANCE_SCALE: f32 = 2.0 * (1u32 << 31) as f32;
@@ -59,7 +58,7 @@ impl PeersStore {
             let mut results = Vec::with_capacity(20);
 
             let mut chunk = vec![0_u8; info_hash_lru.iter().len() * 4];
-            getrandom(chunk.as_mut_slice()).expect("getrandom");
+            getrandom::fill(chunk.as_mut_slice()).expect("getrandom");
 
             for (index, (_, addr)) in info_hash_lru.iter().enumerate() {
                 // Calculate the chance of adding the current item based on remaining items and slots

--- a/src/rpc/server/tokens.rs
+++ b/src/rpc/server/tokens.rs
@@ -1,7 +1,6 @@
 //! Manage tokens for remote client IPs.
 
 use crc::{Crc, CRC_32_ISCSI};
-use getrandom::getrandom;
 use std::{
     fmt::{self, Debug, Formatter},
     net::SocketAddrV4,
@@ -98,7 +97,7 @@ impl Default for Tokens {
 
 fn random() -> [u8; SECRET_SIZE] {
     let mut bytes = [0_u8; SECRET_SIZE];
-    getrandom(&mut bytes).expect("getrandom");
+    getrandom::fill(&mut bytes).expect("getrandom");
 
     bytes
 }


### PR DESCRIPTION
After updating mainline I got compile errors due to me running with `--default-features=false, features = ["node"]`. I initially moved `Testnnet` into `cfg(test)` instead since I assumed it's for internal testing only but I noticed it was publicly exported so didn't want to do a semver breaking change.

I've also taken the liberty to bump some dependencies that my own `cargo-deny` check complained about