### PR TITLE
Switch to u32 for TIDs

### DIFF
--- a/src/common/messages.rs
+++ b/src/common/messages.rs
@@ -15,7 +15,7 @@ use super::InvalidIdSize;
 
 #[derive(Debug, PartialEq, Clone)]
 pub(crate) struct Message {
-    pub transaction_id: u16,
+    pub transaction_id: u32,
 
     /// The version of the requester or responder.
     pub version: Option<[u8; 4]>,
@@ -401,7 +401,7 @@ impl Message {
 
     fn from_serde_message(msg: internal::DHTMessage) -> Result<Message, DecodeMessageError> {
         Ok(Message {
-            transaction_id: u16::from_be_bytes(msg.transaction_id),
+            transaction_id: u32::from_be_bytes(msg.transaction_id),
             version: msg.version,
             requester_ip: match msg.ip {
                 Some(ip) => Some(bytes_to_sockaddr(ip)?),
@@ -981,7 +981,7 @@ mod tests {
         let serde_message = internal::DHTMessage {
             ip: None,
             read_only: None,
-            transaction_id: [1, 2],
+            transaction_id: [1, 2, 3, 4],
             version: None,
             variant: internal::DHTMessageVariant::Response(
                 internal::DHTResponseSpecific::NoValues {

--- a/src/common/messages/internal.rs
+++ b/src/common/messages/internal.rs
@@ -6,7 +6,7 @@ pub struct DHTMessage {
     #[serde(rename = "t", with = "serde_bytes")]
     // Only few messages received seems to not use exactly 2 bytes,
     // and they don't seem to have a version.
-    pub transaction_id: [u8; 2],
+    pub transaction_id: [u8; 4],
 
     #[serde(default)]
     #[serde(rename = "v", with = "serde_bytes")]

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -311,7 +311,7 @@ impl Rpc {
     }
 
     /// Send a request to the given address and return the transaction_id
-    pub fn request(&mut self, address: SocketAddrV4, request: RequestSpecific) -> u16 {
+    pub fn request(&mut self, address: SocketAddrV4, request: RequestSpecific) -> u32 {
         self.socket.request(address, request)
     }
 
@@ -319,14 +319,14 @@ impl Rpc {
     pub fn response(
         &mut self,
         address: SocketAddrV4,
-        transaction_id: u16,
+        transaction_id: u32,
         response: ResponseSpecific,
     ) {
         self.socket.response(address, transaction_id, response)
     }
 
     /// Send an error to the given address.
-    pub fn error(&mut self, address: SocketAddrV4, transaction_id: u16, error: ErrorSpecific) {
+    pub fn error(&mut self, address: SocketAddrV4, transaction_id: u32, error: ErrorSpecific) {
         self.socket.error(address, transaction_id, error)
     }
 
@@ -513,7 +513,7 @@ impl Rpc {
     fn handle_request(
         &mut self,
         from: SocketAddrV4,
-        transaction_id: u16,
+        transaction_id: u32,
         request_specific: RequestSpecific,
     ) {
         // By default we only add nodes that responds to our requests.

--- a/src/rpc/iterative_query.rs
+++ b/src/rpc/iterative_query.rs
@@ -21,7 +21,7 @@ pub(crate) struct IterativeQuery {
     pub request: RequestSpecific,
     closest: ClosestNodes,
     responders: ClosestNodes,
-    inflight_requests: Vec<u16>,
+    inflight_requests: Vec<u32>,
     visited: HashSet<SocketAddrV4>,
     responses: Vec<Response>,
     public_address_votes: HashMap<SocketAddrV4, u16>,
@@ -146,7 +146,7 @@ impl IterativeQuery {
     }
 
     /// Return true if a response (by transaction_id) is expected by this query.
-    pub fn inflight(&self, tid: u16) -> bool {
+    pub fn inflight(&self, tid: u32) -> bool {
         self.inflight_requests.contains(&tid)
     }
 

--- a/src/rpc/put_query.rs
+++ b/src/rpc/put_query.rs
@@ -17,7 +17,7 @@ pub struct PutQuery {
     pub target: Id,
     /// Nodes that confirmed success
     stored_at: u8,
-    inflight_requests: Vec<u16>,
+    inflight_requests: Vec<u32>,
     pub request: PutRequestSpecific,
     errors: Vec<(u8, ErrorSpecific)>,
     extra_nodes: Box<[Node]>,
@@ -80,7 +80,7 @@ impl PutQuery {
         !self.inflight_requests.is_empty()
     }
 
-    pub fn inflight(&self, tid: u16) -> bool {
+    pub fn inflight(&self, tid: u32) -> bool {
         self.inflight_requests.contains(&tid)
     }
 

--- a/src/rpc/socket.rs
+++ b/src/rpc/socket.rs
@@ -25,11 +25,11 @@ pub const MAX_THREAD_BLOCK_DURATION: Duration = Duration::from_millis(10);
 /// A UdpSocket wrapper that formats and correlates DHT requests and responses.
 #[derive(Debug)]
 pub struct KrpcSocket {
-    next_tid: u16,
+    next_tid: u32,
     socket: UdpSocket,
     pub(crate) server_mode: bool,
     request_timeout: Duration,
-    inflight_requests: BTreeMap<u16, InflightRequest>,
+    inflight_requests: BTreeMap<u32, InflightRequest>,
 
     local_addr: SocketAddrV4,
 }
@@ -96,12 +96,12 @@ impl KrpcSocket {
     // === Public Methods ===
 
     /// Returns true if this message's transaction_id is still inflight
-    pub fn inflight(&self, transaction_id: &u16) -> bool {
+    pub fn inflight(&self, transaction_id: &u32) -> bool {
         self.inflight_requests.contains_key(transaction_id)
     }
 
     /// Send a request to the given address and return the transaction_id
-    pub fn request(&mut self, address: SocketAddrV4, request: RequestSpecific) -> u16 {
+    pub fn request(&mut self, address: SocketAddrV4, request: RequestSpecific) -> u32 {
         let message = self.request_message(request);
         trace!(context = "socket_message_sending", message = ?message);
 
@@ -123,7 +123,7 @@ impl KrpcSocket {
     pub fn response(
         &mut self,
         address: SocketAddrV4,
-        transaction_id: u16,
+        transaction_id: u32,
         response: ResponseSpecific,
     ) {
         let message =
@@ -135,7 +135,7 @@ impl KrpcSocket {
     }
 
     /// Send an error to the given address.
-    pub fn error(&mut self, address: SocketAddrV4, transaction_id: u16, error: ErrorSpecific) {
+    pub fn error(&mut self, address: SocketAddrV4, transaction_id: u32, error: ErrorSpecific) {
         let message = self.response_message(MessageType::Error(error), address, transaction_id);
         let _ = self.send(address, message).map_err(|e| {
             debug!(?e, "Error sending error message");
@@ -254,10 +254,10 @@ impl KrpcSocket {
     }
 
     /// Increments self.next_tid and returns the previous value.
-    fn tid(&mut self) -> u16 {
+    fn tid(&mut self) -> u32 {
         // We don't bother much with reusing freed transaction ids,
         // since the timeout is so short we are unlikely to run out
-        // of 65535 ids in 2 seconds.
+        // of 4294967295 ids in 2 seconds.
         let tid = self.next_tid;
         self.next_tid = self.next_tid.wrapping_add(1);
         tid
@@ -281,7 +281,7 @@ impl KrpcSocket {
         &mut self,
         message: MessageType,
         requester_ip: SocketAddrV4,
-        request_tid: u16,
+        request_tid: u32,
     ) -> Message {
         Message {
             transaction_id: request_tid,
@@ -342,9 +342,9 @@ mod test {
         assert_eq!(socket.tid(), 1);
         assert_eq!(socket.tid(), 2);
 
-        socket.next_tid = u16::MAX;
+        socket.next_tid = u32::MAX;
 
-        assert_eq!(socket.tid(), 65535);
+        assert_eq!(socket.tid(), 4294967295);
         assert_eq!(socket.tid(), 0);
     }
 


### PR DESCRIPTION
Expands id space from `65535` to `4294967295` possible IDs to solve wrap around problem and reduce collision risk. While [BEP-5](https://www.bittorrent.org/beps/bep_0005.html) mentions "typically 2 characters" are used for transaction ids, I have not seen any failures with this new approach so far and connectivity seems to be on par with u16.