### PR TITLE
Use set_read_timeout for udp socket

### DIFF
--- a/src/rpc/socket/inflight_requests.rs
+++ b/src/rpc/socket/inflight_requests.rs
@@ -83,4 +83,8 @@ impl InflightRequests {
         // Remove expired requests in a single pass using retain
         self.requests.retain(|_, request| request.sent_at > cutoff);
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.requests.is_empty()
+    }
 }


### PR DESCRIPTION
This PR changes our udp socket from a non-blocking to a blocking socket by using `set_read_timeout`.  