### PR TITLE
refactor: use regular blocking socket

### DIFF
--- a/src/rpc/socket.rs
+++ b/src/rpc/socket.rs
@@ -19,13 +19,6 @@ pub const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_millis(2000); // 2 
 
 pub const READ_TIMEOUT: Duration = Duration::from_millis(50);
 
-// /// Minimum interval between polling udp socket, lower latency, higher cpu usage.
-// /// Useful for checking for expected responses.
-// pub const MIN_POLL_INTERVAL: Duration = Duration::from_micros(100);
-// /// Maximum interval between polling udp socket, higher latency, lower cpu usage.
-// /// Useful for waiting for incoming requests, and periodic node maintenance.
-// pub const MAX_POLL_INTERVAL: Duration = Duration::from_secs(1);
-
 /// Cleanup interval for expired inflight requests to avoid overhead on every recv
 const INFLIGHT_CLEANUP_INTERVAL: Duration = Duration::from_millis(200);
 
@@ -149,15 +142,6 @@ impl KrpcSocket {
 
         match self.socket.recv_from(&mut buf) {
             Ok((amt, SocketAddr::V4(from))) => {
-                // if self.poll_interval > MIN_POLL_INTERVAL {
-                //     if !self.inflight_requests.is_empty() {
-                //         self.poll_interval = MIN_POLL_INTERVAL;
-                //     } else if self.server_mode {
-                //         self.poll_interval = (self.poll_interval / 2).max(MIN_POLL_INTERVAL);
-                //     }
-                //     let _ = self.socket.set_read_timeout(Some(self.poll_interval));
-                // }
-
                 let bytes = &buf[..amt];
 
                 if from.port() == 0 {
@@ -222,12 +206,7 @@ impl KrpcSocket {
                 );
             }
             Err(error) => match error.kind() {
-                ErrorKind::WouldBlock => {
-                    // if self.poll_interval < MAX_POLL_INTERVAL {
-                    //     self.poll_interval = (self.poll_interval * 2).min(MAX_POLL_INTERVAL);
-                    //     let _ = self.socket.set_read_timeout(Some(self.poll_interval));
-                    // }
-                }
+                ErrorKind::WouldBlock => {}
                 _ => {
                     warn!("IO error {error}")
                 }


### PR DESCRIPTION
Compared current `main` branch with a simple blocking socket (50ms).

A simple blocking socket is consuming about the same CPU (+15%?) but is significantly faster (~1.2s).

```
Branch.  CPU ----- Avg. Time   Turns Sleep
main      1.36       5039ms     10        8s
PR         1.42        3593ms     10        8s
main      3.35       4595ms      30       8s
PR         3.68        3650ms.    30        8s
main      3.14        4850ms      30       1s
PR         3.25        3489ms     30        1s
```

Testing script

```rust
use std::{thread::sleep, time::{Duration, Instant}};
use mainline::Dht;

fn main() {
    let dht = Dht::client().unwrap();

    let mut elapsed_sum = 0;
    for i in 0..30 {
        let value = format!("teste{}", i);
        let value_bytes = value.as_bytes();
        println!("\n{i} - Storing immutable data {}", value);
        let elapsed = put_immutable(&dht, &value_bytes);
        elapsed_sum += elapsed;
        println!("Elapsed time: {:?} milliseconds", elapsed);
        println!("Average elapsed time: {:?} milliseconds", elapsed_sum / (i + 1));
        sleep(Duration::from_secs(1));
        println!()
    }

}

fn put_immutable(dht: &Dht, value: &[u8]) -> u128 {
    let start = Instant::now();
    dht.put_immutable(value).expect("put immutable failed");
    start.elapsed().as_millis()
}
```