### PR TITLE
feat: protocol_id for network isolation

### DIFF
--- a/examples/protocol_id.rs
+++ b/examples/protocol_id.rs
@@ -1,0 +1,47 @@
+//! Example demonstrating network isolation using protocol IDs.
+//!
+//! This example shows how to create isolated DHT networks that don't interfere
+//! with each other using the protocol ID.
+//!
+//! Run with:
+//! ```bash
+//! cargo run --example protocol_id
+//! ```
+
+use mainline::{Dht, DEFAULT_STAGING_PROTOCOL_ID};
+
+fn main() -> Result<(), std::io::Error> {
+    println!("Protocol ID Example\n");
+
+    // Example 1: Default behavior - participates in main BitTorrent DHT
+    println!("1. Creating DHT node without protocol ID (default behavior):");
+    println!("   This node will communicate with the main BitTorrent DHT network");
+    let _default_dht = Dht::client()?;
+    println!("   ✓ Created\n");
+
+    // Example 2: Using a custom protocol ID for an isolated network
+    println!("2. Creating DHT node with custom protocol ID:");
+    println!("   Protocol ID: /myapp/mainline/1.0.0");
+    println!("   This node will only communicate with other nodes using the same protocol ID");
+    let _custom_dht = Dht::builder()
+        .protocol_id("/myapp/mainline/1.0.0")
+        .build()?;
+    println!("   ✓ Created\n");
+
+    // Example 3: Using the default staging protocol ID constant
+    println!("4. Creating DHT node using DEFAULT_STAGING_PROTOCOL_ID:");
+    println!("   Protocol ID: {}", DEFAULT_STAGING_PROTOCOL_ID);
+    println!("   Useful for creating isolated test networks");
+    let _staging_dht = Dht::builder()
+        .protocol_id(DEFAULT_STAGING_PROTOCOL_ID)
+        .build()?;
+    println!("   ✓ Created\n");
+
+    println!("Network Isolation Rules:");
+    println!("• Nodes with the same protocol ID can communicate");
+    println!("• Nodes with different protocol IDs ignore each other's messages");
+    println!("• Nodes without a protocol ID (None) accept all messages (backward compatible)");
+    println!("• Nodes with a protocol ID ONLY accept messages with matching protocol ID");
+
+    Ok(())
+}

--- a/src/common/messages/internal.rs
+++ b/src/common/messages/internal.rs
@@ -23,6 +23,11 @@ pub struct DHTMessage {
     #[serde(default)]
     #[serde(rename = "ro")]
     pub read_only: Option<i32>,
+
+    #[serde(default)]
+    #[serde(rename = "p", with = "serde_bytes")]
+    /// protocol ID for network isolation
+    pub protocol_id: Option<Box<[u8]>>,
 }
 
 impl DHTMessage {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,9 @@ pub use rpc::{
 
 pub use ed25519_dalek::SigningKey;
 
+/// Default protocol ID for staging isolated network
+pub const DEFAULT_STAGING_PROTOCOL_ID: &str = "/pubky_staging/mainline/1.0.0";
+
 pub mod errors {
     //! Exported errors
     #[cfg(feature = "node")]

--- a/src/rpc/config.rs
+++ b/src/rpc/config.rs
@@ -35,6 +35,13 @@ pub struct Config {
     ///
     /// Defaults to None, where we depend on suggestions from responding nodes.
     pub public_ip: Option<Ipv4Addr>,
+    /// Optional protocol ID for network isolation
+    ///
+    /// When Some(id) only accepts messages with matching protocol ID.
+    /// When None, accepts all messages.
+    ///
+    /// Defaults to None
+    pub protocol_id: Option<String>,
 }
 
 impl Default for Config {
@@ -46,6 +53,7 @@ impl Default for Config {
             server_settings: Default::default(),
             server_mode: false,
             public_ip: None,
+            protocol_id: None,
         }
     }
 }


### PR DESCRIPTION
We're seeing both Staging and Production data being indexed by Nexus in either environment, calling for better full-stack isolation. This is a concept PR which allows for separation of a Staging DHT network alongside the Staging Homeserver.

This isolation would require changes to our client code also to specify when to DHT query the Stagin network instead of production.  