### PR TITLE
feat: expose stored_at from PUT queries

### DIFF
--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -493,17 +493,17 @@ impl Actor {
     // === tick() helpers ===
 
     /// Advance all PUT queries, return done ones.
-    fn tick_put_queries(&mut self) -> Vec<(Id, Option<PutError>)> {
+    fn tick_put_queries(&mut self) -> Vec<(Id, u8, Option<PutError>)> {
         let mut done_put_queries = Vec::with_capacity(self.put_queries.len());
 
         for (id, query) in self.put_queries.iter_mut() {
             match query.tick(&self.socket) {
                 Ok(done) => {
                     if done {
-                        done_put_queries.push((*id, None));
+                        done_put_queries.push((*id, query.stored_at(), None));
                     }
                 }
-                Err(error) => done_put_queries.push((*id, Some(error))),
+                Err(error) => done_put_queries.push((*id, query.stored_at(), Some(error))),
             };
         }
 
@@ -553,7 +553,7 @@ impl Actor {
     fn cleanup_done_queries(
         &mut self,
         done_get: &[(Id, Box<[Node]>)],
-        done_put: &mut Vec<(Id, Option<PutError>)>,
+        done_put: &mut Vec<(Id, u8, Option<PutError>)>,
     ) {
         // Has to happen _before_ `self.socket.recv_from()`.
         for (id, closest_nodes) in done_get {
@@ -580,11 +580,11 @@ impl Actor {
             }
 
             if let Err(error) = put_query.start(&mut self.socket, closest_nodes) {
-                done_put.push((*id, Some(error)))
+                done_put.push((*id, put_query.stored_at(), Some(error)))
             }
         }
 
-        for (id, _) in done_put.iter() {
+        for (id, _, _) in done_put.iter() {
             self.put_queries.remove(id);
         }
     }
@@ -618,8 +618,8 @@ impl Actor {
 pub struct RpcTickReport {
     /// Completed GET queries with their closest nodes.
     pub done_get_queries: Vec<(Id, Box<[Node]>)>,
-    /// Completed PUT queries; `Some(err)` on failure.
-    pub done_put_queries: Vec<(Id, Option<PutError>)>,
+    /// Completed PUT queries with stored_at count; `Some(err)` on failure.
+    pub done_put_queries: Vec<(Id, u8, Option<PutError>)>,
     /// A value response received for an in-flight GET query.
     pub new_query_response: Option<(Id, Response)>,
 }

--- a/src/core/put_query.rs
+++ b/src/core/put_query.rs
@@ -76,6 +76,10 @@ impl PutQuery {
         Ok(())
     }
 
+    pub fn stored_at(&self) -> u8 {
+        self.stored_at
+    }
+
     pub fn started(&self) -> bool {
         !self.inflight_requests.is_empty()
     }

--- a/src/dht.rs
+++ b/src/dht.rs
@@ -26,6 +26,15 @@ use crate::{
 
 use crate::actor::config::Config;
 
+/// Result of a successful PUT query, including how many DHT nodes stored the value.
+#[derive(Debug, Clone)]
+pub struct PutResult {
+    /// The target Id of the stored value.
+    pub target: Id,
+    /// Number of DHT nodes that acknowledged storing the value.
+    pub stored_at: u8,
+}
+
 #[derive(Debug, Clone)]
 /// Mainline Dht node.
 pub struct Dht(pub(crate) Sender<ActorMessage>);
@@ -463,6 +472,33 @@ impl Dht {
         self.put_inner(request, extra_nodes)
             .recv()
             .expect("Query was dropped before sending a response, please open an issue.")
+            .map(|r| r.target)
+    }
+
+    /// Same as put, but returns a [PutResult] instead of just the target Id.
+    pub fn put_with_info(
+        &self,
+        request: PutRequestSpecific,
+        extra_nodes: Option<Box<[Node]>>,
+    ) -> Result<PutResult, PutError> {
+        self.put_inner(request, extra_nodes)
+            .recv()
+            .expect("Query was dropped before sending a response, please open an issue.")
+    }
+
+    /// Same as put_mutable, but returns a [PutResult] instead of just the target Id.
+    pub fn put_mutable_with_info(
+        &self,
+        item: MutableItem,
+        cas: Option<i64>,
+    ) -> Result<PutResult, PutMutableError> {
+        let request = PutRequestSpecific::PutMutable(PutMutableRequestArguments::from(item, cas));
+
+        self.put_with_info(request, None)
+            .map_err(|error| match error {
+                PutError::Query(err) => PutMutableError::Query(err),
+                PutError::Concurrency(err) => PutMutableError::Concurrency(err),
+            })
     }
 
     // === Private Methods ===
@@ -471,8 +507,8 @@ impl Dht {
         &self,
         request: PutRequestSpecific,
         extra_nodes: Option<Box<[Node]>>,
-    ) -> flume::Receiver<Result<Id, PutError>> {
-        let (tx, rx) = flume::bounded::<Result<Id, PutError>>(1);
+    ) -> flume::Receiver<Result<PutResult, PutError>> {
+        let (tx, rx) = flume::bounded::<Result<PutResult, PutError>>(1);
         self.send(ActorMessage::Put(request, tx, extra_nodes));
 
         rx
@@ -584,12 +620,15 @@ fn run(config: Config, receiver: Receiver<ActorMessage>) {
                 }
 
                 // Cleanup done PUT query and send a resulting error if any.
-                for (id, error) in report.done_put_queries {
+                for (id, stored_at, error) in report.done_put_queries {
                     if let Some(senders) = put_senders.remove(&id) {
                         let result = if let Some(error) = error {
                             Err(error)
                         } else {
-                            Ok(id)
+                            Ok(PutResult {
+                                target: id,
+                                stored_at,
+                            })
                         };
 
                         for sender in senders {
@@ -627,7 +666,7 @@ pub(crate) enum ActorMessage {
     Info(Sender<Info>),
     Put(
         PutRequestSpecific,
-        Sender<Result<Id, PutError>>,
+        Sender<Result<PutResult, PutError>>,
         Option<Box<[Node]>>,
     ),
     Get(GetRequestSpecific, ResponseSender),
@@ -1139,7 +1178,7 @@ mod test {
         {
             let item = MutableItem::new(signer.clone(), &[], 1000, None);
 
-            let (sender, _) = flume::bounded::<Result<Id, PutError>>(1);
+            let (sender, _) = flume::bounded::<Result<PutResult, PutError>>(1);
             let request =
                 PutRequestSpecific::PutMutable(PutMutableRequestArguments::from(item, None));
             client

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ pub use actor::{
 #[cfg(feature = "node")]
 pub use common::ClosestNodes;
 #[cfg(feature = "node")]
-pub use dht::{Dht, DhtBuilder, Testnet, TestnetBuilder};
+pub use dht::{Dht, DhtBuilder, PutResult, Testnet, TestnetBuilder};
 
 pub use ed25519_dalek::SigningKey;
 


### PR DESCRIPTION
Adds `PutResult` with a `stored_at: u8` field that reports how many DHT nodes acknowledged storing a value after a PUT. The existing `put` and `put_mutable` methods are unchanged. New `put_with_info` and `put_mutable_with_info` variants return `PutResult` instead of just the target Id, this means this is a non breaking, backward compatible change.