### PR TITLE
chore: v6.1.2

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -18,7 +18,7 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
@@ -32,13 +32,13 @@ jobs:
     name: MSRV (1.85)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@1.85
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@v3
 
       - name: Check MSRV
         run: cargo check --workspace --all-features
@@ -47,7 +47,7 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
@@ -55,7 +55,7 @@ jobs:
           components: clippy
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@v3
 
       - name: Lint with Clippy
         run: cargo clippy --workspace --all-features --bins --tests -- -D warnings
@@ -64,7 +64,7 @@ jobs:
     name: Cargo Deny
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Check licenses and advisories
         uses: EmbarkStudios/cargo-deny-action@v2
@@ -73,13 +73,13 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@v3
 
       - name: Build
         run: cargo build --release --workspace --all-features --verbose
@@ -92,13 +92,13 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@v3
 
       - name: Run tests
         run: cargo test --all-features --workspace --verbose
@@ -107,13 +107,13 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@v3
 
       - name: Build docs
         run: cargo doc --workspace --all-features --no-deps --document-private-items --verbose

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -38,7 +38,7 @@ jobs:
         uses: dtolnay/rust-toolchain@1.85
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@v3
+        uses: Swatinem/rust-cache@v2
 
       - name: Check MSRV
         run: cargo check --workspace --all-features
@@ -55,7 +55,7 @@ jobs:
           components: clippy
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@v3
+        uses: Swatinem/rust-cache@v2
 
       - name: Lint with Clippy
         run: cargo clippy --workspace --all-features --bins --tests -- -D warnings
@@ -79,7 +79,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@v3
+        uses: Swatinem/rust-cache@v2
 
       - name: Build
         run: cargo build --release --workspace --all-features --verbose
@@ -98,7 +98,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@v3
+        uses: Swatinem/rust-cache@v2
 
       - name: Run tests
         run: cargo test --all-features --workspace --verbose
@@ -113,7 +113,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@v3
+        uses: Swatinem/rust-cache@v2
 
       - name: Build docs
         run: cargo doc --workspace --all-features --no-deps --document-private-items --verbose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to mainline dht will be documented in this file.
 
+## [6.1.2](https://github.com/pubky/mainline/compare/v6.1.1...v6.1.2) - 2026-03-12
+
+### Changed
+
+- Update digest pin from 0.11.0-rc.9 to 0.11.0-rc.10 (#93).
+
 ## [6.1.1](https://github.com/pubky/mainline/compare/v6.1.0...v6.1.1) - 2026-02-05
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,12 @@
 
 All notable changes to mainline dht will be documented in this file.
 
-### Changed
+## [6.1.2](https://github.com/pubky/mainline/compare/v6.1.1...v6.1.2) - 2026-04-28
 
-- Update digest pin from 0.11.0-rc.9 to 0.11.0 (#97).
-
-## [6.1.2](https://github.com/pubky/mainline/compare/v6.1.1...v6.1.2) - 2026-03-12
-
-### Changed
-
-- Update digest pin from 0.11.0-rc.9 to 0.11.0-rc.10 (#93).
+- fix: Typo in log message for invalid ID by @dezren39 in https://github.com/pubky/mainline/pull/96
+- chore: Update digest dependency version to 0.11 by @emmyoh in https://github.com/pubky/mainline/pull/97
+- chore: Update digest pin by @eminence in https://github.com/pubky/mainline/pull/93
+- chore: Release flow + guide by @SeverinAlexB in https://github.com/pubky/mainline/pull/95
 
 ## [6.1.1](https://github.com/pubky/mainline/compare/v6.1.0...v6.1.1) - 2026-02-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to mainline dht will be documented in this file.
 
+### Changed
+
+- Update digest pin from 0.11.0-rc.9 to 0.11.0 (#97).
+
 ## [6.1.2](https://github.com/pubky/mainline/compare/v6.1.1...v6.1.2) - 2026-03-12
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mainline"
-version = "6.1.1"
+version = "6.1.2"
 authors = [
     "nuh.dev",
     "SeverinAlexB <severin@synonym.to>",


### PR DESCRIPTION
### Changed

- Update digest pin from 0.11.0-rc.9 to 0.11.0-rc.10 (#93).