### PR TITLE
feat(rpc): expose bootstrap config

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,9 +22,10 @@ pub use common::{Id, MutableItem, Node, RoutingTable};
 pub use dht::{Dht, DhtBuilder, Testnet, TestnetBuilder};
 #[cfg(feature = "node")]
 pub use rpc::{
+    config::Config,
     messages::{MessageType, PutRequestSpecific, RequestSpecific},
     server::{RequestFilter, ServerSettings, MAX_INFO_HASHES, MAX_PEERS, MAX_VALUES},
-    ClosestNodes, DEFAULT_REQUEST_TIMEOUT,
+    ClosestNodes, DEFAULT_BOOTSTRAP_NODES, DEFAULT_REQUEST_TIMEOUT,
 };
 
 pub use ed25519_dalek::SigningKey;

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -39,6 +39,7 @@ pub use iterative_query::GetRequestSpecific;
 pub use put_query::{ConcurrencyError, PutError, PutQueryError};
 pub use socket::DEFAULT_REQUEST_TIMEOUT;
 
+/// Default bootstrap nodes used to discover peers when no custom bootstrap list is configured.
 pub const DEFAULT_BOOTSTRAP_NODES: [&str; 4] = [
     "router.bittorrent.com:6881",
     "dht.transmissionbt.com:6881",


### PR DESCRIPTION
`mainline::Dht::new()` method is exposed, but its `Config` argument was not.