### PR TITLE
fix(dht): select mutable item by highest sequence

### DIFF
--- a/src/async_dht.rs
+++ b/src/async_dht.rs
@@ -10,9 +10,10 @@ use futures_lite::{Stream, StreamExt};
 
 use crate::{
     common::{
-        hash_immutable, AnnouncePeerRequestArguments, FindNodeRequestArguments,
-        GetPeersRequestArguments, GetValueRequestArguments, Id, MutableItem, Node,
-        PutImmutableRequestArguments, PutMutableRequestArguments, PutRequestSpecific,
+        hash_immutable, most_recent_mutable_item, AnnouncePeerRequestArguments,
+        FindNodeRequestArguments, GetPeersRequestArguments, GetValueRequestArguments, Id,
+        MutableItem, Node, PutImmutableRequestArguments, PutMutableRequestArguments,
+        PutRequestSpecific,
     },
     dht::{ActorMessage, Dht, PutMutableError, ResponseSender},
     rpc::{GetRequestSpecific, Info, PutError, PutQueryError},
@@ -220,20 +221,9 @@ impl AsyncDht {
         public_key: &[u8; 32],
         salt: Option<&[u8]>,
     ) -> Option<MutableItem> {
-        let mut most_recent: Option<MutableItem> = None;
-        let mut stream = self.get_mutable(public_key, salt, None);
-
-        while let Some(item) = stream.next().await {
-            if let Some(mr) = &most_recent {
-                if item.seq() == mr.seq && item.value() > &mr.value {
-                    most_recent = Some(item)
-                }
-            } else {
-                most_recent = Some(item);
-            }
-        }
-
-        most_recent
+        self.get_mutable(public_key, salt, None)
+            .fold(None::<MutableItem>, most_recent_mutable_item)
+            .await
     }
 
     /// Put a mutable data to the DHT.
@@ -532,6 +522,47 @@ mod test {
                 .await;
 
             assert!(&response.is_none());
+        }
+
+        futures::executor::block_on(test());
+    }
+
+    #[test]
+    fn get_mutable_most_recent_prefers_highest_seq() {
+        async fn test() {
+            let testnet = Testnet::builder(10).build().unwrap();
+
+            let dht = Dht::builder()
+                .bootstrap(&testnet.bootstrap)
+                .bind_address(Ipv4Addr::LOCALHOST)
+                .build()
+                .unwrap()
+                .as_async();
+
+            let signer = SigningKey::from_bytes(&[
+                56, 171, 62, 85, 105, 58, 155, 209, 189, 8, 59, 109, 137, 84, 84, 201, 221, 115, 7,
+                228, 127, 70, 4, 204, 182, 64, 77, 98, 92, 215, 27, 103,
+            ]);
+
+            let newer = MutableItem::new(signer.clone(), b"newer", 1001, None);
+            dht.put_mutable(newer.clone(), None).await.unwrap();
+
+            let older = MutableItem::new(signer, b"older", 1000, None);
+            let (sender, _) = flume::bounded::<Result<Id, PutError>>(1);
+            let request =
+                PutRequestSpecific::PutMutable(PutMutableRequestArguments::from(older, None));
+            dht.0
+                 .0
+                .send(ActorMessage::Put(request, sender, None))
+                .unwrap();
+
+            let most_recent = dht
+                .get_mutable_most_recent(newer.key(), None)
+                .await
+                .expect("No mutable values");
+
+            assert_eq!(most_recent.seq(), newer.seq());
+            assert_eq!(most_recent.value(), newer.value());
         }
 
         futures::executor::block_on(test());

--- a/src/common.rs
+++ b/src/common.rs
@@ -10,6 +10,7 @@ mod routing_table;
 pub use id::*;
 pub use immutable::*;
 pub use messages::*;
+pub(crate) use mutable::most_recent_mutable_item;
 pub use mutable::*;
 pub use node::*;
 pub use routing_table::*;

--- a/src/common/mutable.rs
+++ b/src/common/mutable.rs
@@ -151,6 +151,20 @@ pub fn encode_signable(seq: i64, value: &[u8], salt: Option<&[u8]>) -> Box<[u8]>
     signable.into()
 }
 
+pub(crate) fn most_recent_mutable_item(
+    most_recent: Option<MutableItem>,
+    item: MutableItem,
+) -> Option<MutableItem> {
+    match most_recent {
+        Some(mr)
+            if mr.seq() > item.seq() || (mr.seq() == item.seq() && mr.value() >= item.value()) =>
+        {
+            Some(mr)
+        }
+        _ => Some(item),
+    }
+}
+
 #[derive(thiserror::Error, Debug)]
 /// Mainline crate error enum.
 pub enum MutableError {
@@ -197,6 +211,8 @@ impl From<PutMutableRequestArguments> for MutableItem {
 mod tests {
     use super::*;
 
+    use ed25519_dalek::SigningKey;
+
     #[test]
     fn signable_without_salt() {
         let signable = encode_signable(4, b"Hello world!", None);
@@ -208,5 +224,49 @@ mod tests {
         let signable = encode_signable(4, b"Hello world!", Some(b"foobar"));
 
         assert_eq!(&*signable, b"4:salt6:foobar3:seqi4e1:v12:Hello world!");
+    }
+
+    #[test]
+    fn most_recent_mutable_item_selects_by_seq_then_value() {
+        let signer = SigningKey::from_bytes(&[
+            56, 171, 62, 85, 105, 58, 155, 209, 189, 8, 59, 109, 137, 84, 84, 201, 221, 115, 7,
+            228, 127, 70, 4, 204, 182, 64, 77, 98, 92, 215, 27, 103,
+        ]);
+
+        let lower_seq = MutableItem::new(signer.clone(), b"lower-seq", 999, None);
+        let current = MutableItem::new(signer.clone(), b"current1", 1000, None);
+        let higher_seq = MutableItem::new(signer.clone(), b"higher-seq", 1001, None);
+        let same_seq_lower_value = MutableItem::new(signer.clone(), b"current0", 1000, None);
+        let same_seq_higher_value = MutableItem::new(signer, b"current2", 1000, None);
+
+        assert_eq!(
+            most_recent_mutable_item(None, current.clone()),
+            Some(current.clone())
+        );
+
+        assert_eq!(
+            most_recent_mutable_item(Some(current.clone()), higher_seq.clone()),
+            Some(higher_seq)
+        );
+
+        assert_eq!(
+            most_recent_mutable_item(Some(current.clone()), lower_seq),
+            Some(current.clone())
+        );
+
+        assert_eq!(
+            most_recent_mutable_item(Some(current.clone()), same_seq_higher_value.clone()),
+            Some(same_seq_higher_value)
+        );
+
+        assert_eq!(
+            most_recent_mutable_item(Some(current.clone()), same_seq_lower_value),
+            Some(current.clone())
+        );
+
+        assert_eq!(
+            most_recent_mutable_item(Some(current.clone()), current.clone()),
+            Some(current)
+        );
     }
 }

--- a/src/dht.rs
+++ b/src/dht.rs
@@ -13,9 +13,9 @@ use tracing::info;
 
 use crate::{
     common::{
-        hash_immutable, AnnouncePeerRequestArguments, FindNodeRequestArguments,
-        GetPeersRequestArguments, GetValueRequestArguments, Id, MutableItem,
-        PutImmutableRequestArguments, PutMutableRequestArguments, PutRequestSpecific,
+        hash_immutable, most_recent_mutable_item, AnnouncePeerRequestArguments,
+        FindNodeRequestArguments, GetPeersRequestArguments, GetValueRequestArguments, Id,
+        MutableItem, PutImmutableRequestArguments, PutMutableRequestArguments, PutRequestSpecific,
     },
     rpc::{
         to_socket_address, ConcurrencyError, GetRequestSpecific, Info, PutError, PutQueryError,
@@ -351,19 +351,8 @@ impl Dht {
         public_key: &[u8; 32],
         salt: Option<&[u8]>,
     ) -> Option<MutableItem> {
-        let mut most_recent: Option<MutableItem> = None;
-        let iter = self.get_mutable(public_key, salt, None);
-        for item in iter {
-            if let Some(mr) = &most_recent {
-                if item.seq() == mr.seq && item.value() > &mr.value {
-                    most_recent = Some(item)
-                }
-            } else {
-                most_recent = Some(item);
-            }
-        }
-
-        most_recent
+        self.get_mutable(public_key, salt, None)
+            .fold(None::<MutableItem>, most_recent_mutable_item)
     }
 
     /// Put a mutable data to the DHT.
@@ -1059,6 +1048,40 @@ mod test {
             .next();
 
         assert!(&response.is_none());
+    }
+
+    #[test]
+    fn get_mutable_most_recent_prefers_highest_seq() {
+        let testnet = Testnet::builder(10).build().unwrap();
+
+        let client = Dht::builder()
+            .bootstrap(&testnet.bootstrap)
+            .bind_address(Ipv4Addr::LOCALHOST)
+            .build()
+            .unwrap();
+
+        let signer = SigningKey::from_bytes(&[
+            56, 171, 62, 85, 105, 58, 155, 209, 189, 8, 59, 109, 137, 84, 84, 201, 221, 115, 7,
+            228, 127, 70, 4, 204, 182, 64, 77, 98, 92, 215, 27, 103,
+        ]);
+
+        let newer = MutableItem::new(signer.clone(), b"newer", 1001, None);
+        client.put_mutable(newer.clone(), None).unwrap();
+
+        let older = MutableItem::new(signer, b"older", 1000, None);
+        let (sender, _) = flume::bounded::<Result<Id, PutError>>(1);
+        let request = PutRequestSpecific::PutMutable(PutMutableRequestArguments::from(older, None));
+        client
+            .0
+            .send(ActorMessage::Put(request, sender, None))
+            .unwrap();
+
+        let most_recent = client
+            .get_mutable_most_recent(newer.key(), None)
+            .expect("No mutable values");
+
+        assert_eq!(most_recent.seq(), newer.seq());
+        assert_eq!(most_recent.value(), newer.value());
     }
 
     #[test]


### PR DESCRIPTION
Fixed sync and async `get_mutable_most_recent()`. Before, it could keep an older item if it arrived first. Now it selects by highest seq, using value ordering only when seq is equal.
Also moved the selection logic into shared `most_recent_mutable_item()` and added tests for the reducer plus sync/async regressions.

