### PR TITLE
feat(async)!: return PUT outcome from raw put

### DIFF
--- a/src/async_dht.rs
+++ b/src/async_dht.rs
@@ -16,7 +16,7 @@ use crate::{
         PutRequestSpecific,
     },
     dht::{ActorMessage, Dht, PutMutableError, ResponseSender},
-    rpc::{GetRequestSpecific, Info, PutError, PutQueryError},
+    rpc::{GetRequestSpecific, Info, PutError, PutOutcome, PutQueryError},
 };
 
 impl Dht {
@@ -135,6 +135,7 @@ impl AsyncDht {
             None,
         )
         .await
+        .map(|outcome| outcome.target)
         .map_err(|error| match error {
             PutError::Query(error) => error,
             PutError::Concurrency(_) => {
@@ -172,6 +173,7 @@ impl AsyncDht {
             None,
         )
         .await
+        .map(|outcome| outcome.target)
         .map_err(|error| match error {
             PutError::Query(error) => error,
             PutError::Concurrency(_) => {
@@ -291,10 +293,13 @@ impl AsyncDht {
     ) -> Result<Id, PutMutableError> {
         let request = PutRequestSpecific::PutMutable(PutMutableRequestArguments::from(item, cas));
 
-        self.put(request, None).await.map_err(|error| match error {
-            PutError::Query(err) => PutMutableError::Query(err),
-            PutError::Concurrency(err) => PutMutableError::Concurrency(err),
-        })
+        self.put(request, None)
+            .await
+            .map(|outcome| outcome.target)
+            .map_err(|error| match error {
+                PutError::Query(err) => PutMutableError::Query(err),
+                PutError::Concurrency(err) => PutMutableError::Concurrency(err),
+            })
     }
 
     // === Raw ===
@@ -328,11 +333,13 @@ impl AsyncDht {
     /// [Self::get_closest_nodes] with the target that you want to find the closest nodes to.
     ///
     /// Note: extra nodes need to have [Node::valid_token].
+    ///
+    /// Returns details about the successful PUT.
     pub async fn put(
         &self,
         request: PutRequestSpecific,
         extra_nodes: Option<Box<[Node]>>,
-    ) -> Result<Id, PutError> {
+    ) -> Result<PutOutcome, PutError> {
         self.put_inner(request, extra_nodes)
             .recv_async()
             .await
@@ -345,8 +352,8 @@ impl AsyncDht {
         &self,
         request: PutRequestSpecific,
         extra_nodes: Option<Box<[Node]>>,
-    ) -> flume::Receiver<Result<Id, PutError>> {
-        let (tx, rx) = flume::bounded::<Result<Id, PutError>>(1);
+    ) -> flume::Receiver<Result<PutOutcome, PutError>> {
+        let (tx, rx) = flume::bounded::<Result<PutOutcome, PutError>>(1);
         self.send(ActorMessage::Put(request, tx, extra_nodes));
 
         rx
@@ -439,6 +446,34 @@ mod test {
 
             let response = b.get_immutable(target).await;
             assert_eq!(response, Some(value.to_vec().into_boxed_slice()));
+        }
+
+        futures::executor::block_on(test());
+    }
+
+    #[test]
+    fn raw_put_immutable_returns_outcome() {
+        async fn test() {
+            let testnet = Testnet::builder(10).build().unwrap();
+
+            let dht = Dht::builder()
+                .bootstrap(&testnet.bootstrap)
+                .bind_address(Ipv4Addr::LOCALHOST)
+                .build()
+                .unwrap()
+                .as_async();
+
+            let value = b"Hello World!";
+            let target: Id = hash_immutable(value).into();
+            let request = PutRequestSpecific::PutImmutable(PutImmutableRequestArguments {
+                target,
+                v: value.as_ref().into(),
+            });
+
+            let outcome = dht.put(request, None).await.unwrap();
+
+            assert_eq!(outcome.target, target);
+            assert!(outcome.stored_at > 0);
         }
 
         futures::executor::block_on(test());
@@ -548,7 +583,7 @@ mod test {
             dht.put_mutable(newer.clone(), None).await.unwrap();
 
             let older = MutableItem::new(signer, b"older", 1000, None);
-            let (sender, _) = flume::bounded::<Result<Id, PutError>>(1);
+            let (sender, _) = flume::bounded::<Result<PutOutcome, PutError>>(1);
             let request =
                 PutRequestSpecific::PutMutable(PutMutableRequestArguments::from(older, None));
             dht.0
@@ -748,7 +783,7 @@ mod test {
             {
                 let item = MutableItem::new(signer.clone(), &value, 1000, None);
 
-                let (sender, _) = flume::bounded::<Result<Id, PutError>>(1);
+                let (sender, _) = flume::bounded::<Result<PutOutcome, PutError>>(1);
                 let request =
                     PutRequestSpecific::PutMutable(PutMutableRequestArguments::from(item, None));
                 dht.0

--- a/src/dht.rs
+++ b/src/dht.rs
@@ -18,8 +18,8 @@ use crate::{
         MutableItem, PutImmutableRequestArguments, PutMutableRequestArguments, PutRequestSpecific,
     },
     rpc::{
-        to_socket_address, ConcurrencyError, GetRequestSpecific, Info, PutError, PutQueryError,
-        Response, Rpc,
+        to_socket_address, ConcurrencyError, GetRequestSpecific, Info, PutError, PutOutcome,
+        PutQueryError, Response, Rpc,
     },
     Node, ServerSettings,
 };
@@ -457,6 +457,7 @@ impl Dht {
         self.put_inner(request, extra_nodes)
             .recv()
             .expect("Query was dropped before sending a response, please open an issue.")
+            .map(|outcome| outcome.target)
     }
 
     // === Private Methods ===
@@ -465,8 +466,8 @@ impl Dht {
         &self,
         request: PutRequestSpecific,
         extra_nodes: Option<Box<[Node]>>,
-    ) -> flume::Receiver<Result<Id, PutError>> {
-        let (tx, rx) = flume::bounded::<Result<Id, PutError>>(1);
+    ) -> flume::Receiver<Result<PutOutcome, PutError>> {
+        let (tx, rx) = flume::bounded::<Result<PutOutcome, PutError>>(1);
         self.send(ActorMessage::Put(request, tx, extra_nodes));
 
         rx
@@ -577,15 +578,9 @@ fn run(config: Config, receiver: Receiver<ActorMessage>) {
                     }
                 }
 
-                // Cleanup done PUT query and send a resulting error if any.
-                for (id, error) in report.done_put_queries {
+                // Cleanup done PUT query and send its final result.
+                for (id, result) in report.done_put_queries {
                     if let Some(senders) = put_senders.remove(&id) {
-                        let result = if let Some(error) = error {
-                            Err(error)
-                        } else {
-                            Ok(id)
-                        };
-
                         for sender in senders {
                             let _ = sender.send(result.clone());
                         }
@@ -621,7 +616,7 @@ pub(crate) enum ActorMessage {
     Info(Sender<Info>),
     Put(
         PutRequestSpecific,
-        Sender<Result<Id, PutError>>,
+        Sender<Result<PutOutcome, PutError>>,
         Option<Box<[Node]>>,
     ),
     Get(GetRequestSpecific, ResponseSender),
@@ -1069,7 +1064,7 @@ mod test {
         client.put_mutable(newer.clone(), None).unwrap();
 
         let older = MutableItem::new(signer, b"older", 1000, None);
-        let (sender, _) = flume::bounded::<Result<Id, PutError>>(1);
+        let (sender, _) = flume::bounded::<Result<PutOutcome, PutError>>(1);
         let request = PutRequestSpecific::PutMutable(PutMutableRequestArguments::from(older, None));
         client
             .0
@@ -1242,7 +1237,7 @@ mod test {
         {
             let item = MutableItem::new(signer.clone(), &[], 1000, None);
 
-            let (sender, _) = flume::bounded::<Result<Id, PutError>>(1);
+            let (sender, _) = flume::bounded::<Result<PutOutcome, PutError>>(1);
             let request =
                 PutRequestSpecific::PutMutable(PutMutableRequestArguments::from(item, None));
             client

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ pub use rpc::{
     config::Config,
     messages::{MessageType, PutRequestSpecific, RequestSpecific},
     server::{RequestFilter, ServerSettings, MAX_INFO_HASHES, MAX_PEERS, MAX_VALUES},
-    ClosestNodes, DEFAULT_BOOTSTRAP_NODES, DEFAULT_REQUEST_TIMEOUT,
+    ClosestNodes, PutOutcome, DEFAULT_BOOTSTRAP_NODES, DEFAULT_REQUEST_TIMEOUT,
 };
 
 pub use ed25519_dalek::SigningKey;

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -36,7 +36,7 @@ pub use crate::common::messages;
 pub use closest_nodes::ClosestNodes;
 pub use info::Info;
 pub use iterative_query::GetRequestSpecific;
-pub use put_query::{ConcurrencyError, PutError, PutQueryError};
+pub use put_query::{ConcurrencyError, PutError, PutOutcome, PutQueryError};
 pub use socket::DEFAULT_REQUEST_TIMEOUT;
 
 /// Default bootstrap nodes used to discover peers when no custom bootstrap list is configured.
@@ -954,17 +954,14 @@ impl Rpc {
     // === tick() helpers ===
 
     /// Advance all PUT queries, return done ones.
-    fn tick_put_queries(&mut self) -> Vec<(Id, Option<PutError>)> {
+    fn tick_put_queries(&mut self) -> Vec<(Id, Result<PutOutcome, PutError>)> {
         let mut done_put_queries = Vec::with_capacity(self.put_queries.len());
 
         for (id, query) in self.put_queries.iter_mut() {
             match query.poll_completion(&self.socket) {
-                Ok(done) => {
-                    if done {
-                        done_put_queries.push((*id, None));
-                    }
-                }
-                Err(error) => done_put_queries.push((*id, Some(error))),
+                Ok(Some(outcome)) => done_put_queries.push((*id, Ok(outcome))),
+                Ok(None) => (),
+                Err(error) => done_put_queries.push((*id, Err(error))),
             };
         }
 
@@ -1014,7 +1011,7 @@ impl Rpc {
     fn cleanup_done_queries(
         &mut self,
         done_get: &[(Id, Box<[Node]>)],
-        done_put: &mut Vec<(Id, Option<PutError>)>,
+        done_put: &mut Vec<(Id, Result<PutOutcome, PutError>)>,
     ) {
         // Has to happen _before_ `self.socket.recv_from()`.
         for (id, closest_nodes) in done_get {
@@ -1041,7 +1038,7 @@ impl Rpc {
             }
 
             if let Err(error) = put_query.start(&mut self.socket, closest_nodes) {
-                done_put.push((*id, Some(error)))
+                done_put.push((*id, Err(error)))
             }
         }
 
@@ -1093,8 +1090,8 @@ pub struct RpcTickReport {
     /// All the [Id]s of the done [Rpc::get] queries.
     pub done_get_queries: Vec<(Id, Box<[Node]>)>,
     /// All the [Id]s of the done [Rpc::put] queries,
-    /// and optional [PutError] if the query failed.
-    pub done_put_queries: Vec<(Id, Option<PutError>)>,
+    /// and either the successful [PutOutcome] or a [PutError].
+    pub done_put_queries: Vec<(Id, Result<PutOutcome, PutError>)>,
     /// Received GET query response.
     pub new_query_response: Option<(Id, Response)>,
 }

--- a/src/rpc/put_query.rs
+++ b/src/rpc/put_query.rs
@@ -17,7 +17,7 @@ use super::socket::KrpcSocket;
 pub struct PutQuery {
     pub target: Id,
     /// Nodes that confirmed success
-    stored_at: u8,
+    stored_at: u32,
     inflight_requests: Vec<u32>,
     pub request: PutRequestSpecific,
     errors: Vec<(u8, ErrorSpecific)>,
@@ -112,10 +112,10 @@ impl PutQuery {
         }
     }
 
-    /// Check if the query has completed.
-    pub fn poll_completion(&self, socket: &KrpcSocket) -> Result<bool, PutError> {
+    /// Check if the query has completed, returning the PUT outcome when complete.
+    pub fn poll_completion(&self, socket: &KrpcSocket) -> Result<Option<PutOutcome>, PutError> {
         if !self.started() {
-            return Ok(false);
+            return Ok(None);
         }
 
         if let Some(most_common_error) = self.majority_nodes_rejected_put_mutable() {
@@ -150,10 +150,13 @@ impl PutQuery {
 
             debug!(?target, stored_at = ?self.stored_at, "PutQuery Done successfully");
 
-            return Ok(true);
+            return Ok(Some(PutOutcome {
+                target: self.target,
+                stored_at: self.stored_at,
+            }));
         }
 
-        Ok(false)
+        Ok(None)
     }
 
     fn is_done(&self, socket: &KrpcSocket) -> bool {
@@ -189,6 +192,16 @@ impl PutQuery {
                 _ => None,
             })
     }
+}
+
+/// Result details for a successful PUT query.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PutOutcome {
+    /// DHT target the request was published under.
+    pub target: Id,
+
+    /// Number of DHT nodes that acknowledged storing the item.
+    pub stored_at: u32,
 }
 
 /// PutQuery errors


### PR DESCRIPTION
Expose `PutOutcome` so callers can inspect both the DHT target and the
number of nodes that acknowledged storing a PUT request.

BREAKING CHANGE: `AsyncDht::put` now returns
`Result<PutOutcome, PutError>` instead of `Result<Id, PutError>`.
