### PR TITLE
fix(rpc)!: stop GET queries from echoing pending PUTs

### DIFF
--- a/src/async_dht.rs
+++ b/src/async_dht.rs
@@ -798,13 +798,7 @@ mod test {
             {
                 let item = MutableItem::new(signer, &value, 1001, None);
 
-                let most_recent = dht.get_mutable_most_recent(item.key(), None).await;
-
-                if let Some(cas) = most_recent.map(|item| item.seq()) {
-                    dht.put_mutable(item, Some(cas)).await.unwrap();
-                } else {
-                    dht.put_mutable(item, None).await.unwrap();
-                }
+                dht.put_mutable(item, Some(1000)).await.unwrap();
             }
         }
 

--- a/src/dht.rs
+++ b/src/dht.rs
@@ -1252,13 +1252,7 @@ mod test {
         {
             let item = MutableItem::new(signer, &[], 1001, None);
 
-            let most_recent = client.get_mutable_most_recent(item.key(), None);
-
-            if let Some(cas) = most_recent.map(|item| item.seq()) {
-                client.put_mutable(item, Some(cas)).unwrap();
-            } else {
-                client.put_mutable(item, None).unwrap();
-            }
+            client.put_mutable(item, Some(1000)).unwrap();
         }
     }
 

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -370,24 +370,9 @@ impl Rpc {
             GetRequestSpecific::GetValue(GetValueRequestArguments { target, .. }) => target,
         };
 
-        let response_from_inflight_put_mutable_request =
-            self.put_queries.get(&target).and_then(|existing| {
-                if let PutRequestSpecific::PutMutable(request) = &existing.request {
-                    Some(Response::Mutable(request.clone().into()))
-                } else {
-                    None
-                }
-            });
-
         // If query is still active, no need to create a new one.
         if let Some(query) = self.iterative_queries.get(&target) {
-            let mut responses = query.responses().to_vec();
-
-            if let Some(response) = response_from_inflight_put_mutable_request {
-                responses.push(response);
-            }
-
-            return Some(responses);
+            return Some(query.responses().to_vec());
         }
 
         let node_id = self.routing_table.id();
@@ -439,11 +424,6 @@ impl Rpc {
         query.start(&mut self.socket);
 
         self.iterative_queries.insert(target, query);
-
-        // If there is an inflight PutQuery for mutable item return its value
-        if let Some(response) = response_from_inflight_put_mutable_request {
-            return Some(vec![response]);
-        }
 
         None
     }
@@ -1118,4 +1098,47 @@ pub(crate) fn to_socket_address<T: ToSocketAddrs>(bootstrap: &[T]) -> Vec<Socket
         })
         .flatten()
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::Ipv4Addr;
+
+    use ed25519_dalek::SigningKey;
+
+    use super::*;
+
+    #[test]
+    fn get_does_not_echo_inflight_mutable_put() {
+        let mut rpc = Rpc::new(config::Config {
+            bootstrap: Some(vec![]),
+            bind_address: Some(Ipv4Addr::LOCALHOST),
+            ..Default::default()
+        })
+        .unwrap();
+
+        let signer = SigningKey::from_bytes(&[
+            56, 171, 62, 85, 105, 58, 155, 209, 189, 8, 59, 109, 137, 84, 84, 201, 221, 115, 7,
+            228, 127, 70, 4, 204, 182, 64, 77, 98, 92, 215, 27, 103,
+        ]);
+
+        let item = MutableItem::new(signer, b"value", 1000, None);
+        let request = PutRequestSpecific::PutMutable(PutMutableRequestArguments::from(item, None));
+        let target = *request.target();
+
+        rpc.put(request, None).unwrap();
+
+        let responses = rpc
+            .get(
+                GetRequestSpecific::GetValue(GetValueRequestArguments {
+                    target,
+                    seq: None,
+                    salt: None,
+                }),
+                None,
+            )
+            .unwrap();
+
+        assert!(responses.is_empty());
+    }
 }


### PR DESCRIPTION
BREAKING CHANGES: Remove the synthetic mutable value returned from
in-flight PUT queries when handling GET lookups for the same target.

The old behavior was dangerous because it made GET results depend on
local actor state instead of DHT node responses. That could make callers
believe a mutable item was already observable on the DHT before any node
had actually stored or returned it, and it made diagnostics/counts
inconsistent with the network responses.

Update CAS tests to pass the known CAS explicitly instead of relying on
GET observing a pending local PUT.
