### PR TITLE
feat(dht): add detailed mutable GET outcome

### DIFF
--- a/src/async_dht.rs
+++ b/src/async_dht.rs
@@ -16,7 +16,7 @@ use crate::{
         PutRequestSpecific,
     },
     dht::{ActorMessage, Dht, PutMutableError, ResponseSender},
-    rpc::{GetRequestSpecific, Info, PutError, PutOutcome, PutQueryError},
+    rpc::{GetMutableOutcome, GetRequestSpecific, Info, PutError, PutOutcome, PutQueryError},
 };
 
 impl Dht {
@@ -202,19 +202,41 @@ impl AsyncDht {
         salt: Option<&[u8]>,
         more_recent_than: Option<i64>,
     ) -> GetStream<MutableItem> {
-        let salt = salt.map(|s| s.into());
+        self.get_mutable_detailed(public_key, salt, more_recent_than)
+            .items
+    }
+
+    /// Get mutable data and final aggregate diagnostics for the lookup.
+    ///
+    /// Valid mutable items are yielded on [GetMutableDetailed::items] as they arrive.
+    /// Final counters are available by awaiting [GetMutableOutcomeReceiver::recv].
+    pub fn get_mutable_detailed(
+        &self,
+        public_key: &[u8; 32],
+        salt: Option<&[u8]>,
+        more_recent_than: Option<i64>,
+    ) -> GetMutableDetailed {
+        let salt = salt.map(Into::into);
         let target = MutableItem::target_from_key(public_key, salt.as_deref());
-        let (tx, rx) = flume::unbounded::<MutableItem>();
+        let (values_tx, values_rx) = flume::unbounded::<MutableItem>();
+        let (outcome_tx, outcome_rx) = flume::bounded::<GetMutableOutcome>(1);
+
         self.send(ActorMessage::Get(
             GetRequestSpecific::GetValue(GetValueRequestArguments {
                 target,
                 seq: more_recent_than,
                 salt,
             }),
-            ResponseSender::Mutable(tx),
+            ResponseSender::MutableDetailed {
+                values: values_tx,
+                outcome: outcome_tx,
+            },
         ));
 
-        GetStream(rx.into_stream())
+        GetMutableDetailed {
+            items: GetStream(values_rx.into_stream()),
+            outcome: GetMutableOutcomeReceiver(outcome_rx),
+        }
     }
 
     /// Get the most recent [MutableItem] from the network.
@@ -376,6 +398,27 @@ impl<T> Stream for GetStream<T> {
     }
 }
 
+/// Mutable GET values stream plus a final diagnostic outcome.
+pub struct GetMutableDetailed {
+    /// Valid mutable items returned by queried DHT nodes.
+    pub items: GetStream<MutableItem>,
+    /// Final aggregate diagnostics for the lookup.
+    pub outcome: GetMutableOutcomeReceiver,
+}
+
+/// Async receiver for a detailed mutable GET outcome.
+pub struct GetMutableOutcomeReceiver(flume::Receiver<GetMutableOutcome>);
+
+impl GetMutableOutcomeReceiver {
+    /// Wait for the mutable GET query to finish and return its aggregate diagnostics.
+    pub async fn recv(self) -> GetMutableOutcome {
+        self.0
+            .recv_async()
+            .await
+            .expect("Query was dropped before sending a response, please open an issue.")
+    }
+}
+
 #[cfg(test)]
 mod test {
     use std::net::Ipv4Addr;
@@ -387,6 +430,19 @@ mod test {
     use crate::{dht::Testnet, rpc::ConcurrencyError};
 
     use super::*;
+
+    fn counted_mutable_responses(outcome: &GetMutableOutcome) -> u32 {
+        outcome.values
+            + outcome.no_values
+            + outcome.no_more_recent
+            + outcome.invalid_values
+            + outcome.invalid_responses
+            + outcome.krpc_errors
+    }
+
+    fn counted_valid_mutable_responses(outcome: &GetMutableOutcome) -> u32 {
+        outcome.values + outcome.no_values + outcome.no_more_recent
+    }
 
     #[test]
     fn announce_get_peer() {
@@ -516,6 +572,137 @@ mod test {
                 .expect("No mutable values");
 
             assert_eq!(&response, &item);
+        }
+
+        futures::executor::block_on(test());
+    }
+
+    #[test]
+    fn get_mutable_detailed_no_values() {
+        async fn test() {
+            let testnet = Testnet::builder(10).build().unwrap();
+
+            let dht = Dht::builder()
+                .bootstrap(&testnet.bootstrap)
+                .bind_address(Ipv4Addr::LOCALHOST)
+                .build()
+                .unwrap()
+                .as_async();
+
+            let signer = SigningKey::from_bytes(&[
+                56, 171, 62, 85, 105, 58, 155, 209, 189, 8, 59, 109, 137, 84, 84, 201, 221, 115, 7,
+                228, 127, 70, 4, 204, 182, 64, 77, 98, 92, 215, 27, 103,
+            ]);
+
+            let detailed = dht.get_mutable_detailed(signer.verifying_key().as_bytes(), None, None);
+            let GetMutableDetailed { items, outcome } = detailed;
+
+            let items = items.collect::<Vec<_>>().await;
+            let outcome = outcome.recv().await;
+
+            assert!(items.is_empty());
+            assert!(outcome.queried > 0);
+            assert_eq!(outcome.values, 0);
+            assert!(outcome.no_values > 0);
+            assert_eq!(
+                outcome.valid_responses(),
+                counted_valid_mutable_responses(&outcome)
+            );
+            assert_eq!(outcome.responded(), counted_mutable_responses(&outcome));
+        }
+
+        futures::executor::block_on(test());
+    }
+
+    #[test]
+    fn get_mutable_detailed_returns_values_outcome() {
+        async fn test() {
+            let testnet = Testnet::builder(10).build().unwrap();
+
+            let a = Dht::builder()
+                .bootstrap(&testnet.bootstrap)
+                .bind_address(Ipv4Addr::LOCALHOST)
+                .build()
+                .unwrap()
+                .as_async();
+            let b = Dht::builder()
+                .bootstrap(&testnet.bootstrap)
+                .bind_address(Ipv4Addr::LOCALHOST)
+                .build()
+                .unwrap()
+                .as_async();
+
+            let signer = SigningKey::from_bytes(&[
+                56, 171, 62, 85, 105, 58, 155, 209, 189, 8, 59, 109, 137, 84, 84, 201, 221, 115, 7,
+                228, 127, 70, 4, 204, 182, 64, 77, 98, 92, 215, 27, 103,
+            ]);
+
+            let item = MutableItem::new(signer.clone(), b"Hello World!", 1000, None);
+            a.put_mutable(item.clone(), None).await.unwrap();
+
+            let detailed = b.get_mutable_detailed(signer.verifying_key().as_bytes(), None, None);
+            let GetMutableDetailed { items, outcome } = detailed;
+
+            let items = items.collect::<Vec<_>>().await;
+            let outcome = outcome.recv().await;
+
+            assert!(items.iter().any(|response| response == &item));
+            assert!(outcome.queried > 0);
+            assert_eq!(outcome.values, items.len() as u32);
+            assert!(outcome.values > 0);
+            assert_eq!(
+                outcome.valid_responses(),
+                counted_valid_mutable_responses(&outcome)
+            );
+            assert_eq!(outcome.responded(), counted_mutable_responses(&outcome));
+        }
+
+        futures::executor::block_on(test());
+    }
+
+    #[test]
+    fn get_mutable_detailed_no_more_recent_value() {
+        async fn test() {
+            let testnet = Testnet::builder(10).build().unwrap();
+
+            let a = Dht::builder()
+                .bootstrap(&testnet.bootstrap)
+                .bind_address(Ipv4Addr::LOCALHOST)
+                .build()
+                .unwrap()
+                .as_async();
+            let b = Dht::builder()
+                .bootstrap(&testnet.bootstrap)
+                .bind_address(Ipv4Addr::LOCALHOST)
+                .build()
+                .unwrap()
+                .as_async();
+
+            let signer = SigningKey::from_bytes(&[
+                56, 171, 62, 85, 105, 58, 155, 209, 189, 8, 59, 109, 137, 84, 84, 201, 221, 115, 7,
+                228, 127, 70, 4, 204, 182, 64, 77, 98, 92, 215, 27, 103,
+            ]);
+
+            let seq = 1000;
+            let item = MutableItem::new(signer.clone(), b"Hello World!", seq, None);
+            a.put_mutable(item, None).await.unwrap();
+
+            let detailed =
+                b.get_mutable_detailed(signer.verifying_key().as_bytes(), None, Some(seq));
+            let GetMutableDetailed { items, outcome } = detailed;
+
+            let items = items.collect::<Vec<_>>().await;
+            let outcome = outcome.recv().await;
+
+            assert!(items.is_empty());
+            assert!(outcome.queried > 0);
+            assert_eq!(outcome.values, 0);
+            assert!(outcome.no_more_recent > 0);
+            assert_eq!(
+                outcome.valid_responses(),
+                counted_valid_mutable_responses(&outcome)
+            );
+            assert_eq!(outcome.responded(), counted_mutable_responses(&outcome));
         }
 
         futures::executor::block_on(test());

--- a/src/dht.rs
+++ b/src/dht.rs
@@ -18,8 +18,8 @@ use crate::{
         MutableItem, PutImmutableRequestArguments, PutMutableRequestArguments, PutRequestSpecific,
     },
     rpc::{
-        to_socket_address, ConcurrencyError, GetRequestSpecific, Info, PutError, PutOutcome,
-        PutQueryError, Response, Rpc,
+        to_socket_address, ConcurrencyError, GetMutableOutcome, GetRequestSpecific, Info, PutError,
+        PutOutcome, PutQueryError, Response, Rpc,
     },
     Node, ServerSettings,
 };
@@ -567,12 +567,20 @@ fn run(config: Config, receiver: Receiver<ActorMessage>) {
                 }
 
                 // Cleanup done GET queries
-                for (id, closest_nodes) in report.done_get_queries {
-                    if let Some(senders) = get_senders.remove(&id) {
+                for done in report.done_get_queries {
+                    if let Some(senders) = get_senders.remove(&done.id) {
                         for sender in senders {
-                            // return closest_nodes to whoever was asking
-                            if let ResponseSender::ClosestNodes(sender) = sender {
-                                let _ = sender.send(closest_nodes.clone());
+                            match sender {
+                                ResponseSender::ClosestNodes(sender) => {
+                                    let _ = sender.send(done.closest_nodes.clone());
+                                }
+                                ResponseSender::MutableDetailed { outcome, .. } => {
+                                    let _ = outcome
+                                        .send(done.mutable_outcome.clone().unwrap_or_default());
+                                }
+                                ResponseSender::Peers(_)
+                                | ResponseSender::Mutable(_)
+                                | ResponseSender::Immutable(_) => {}
                             }
                         }
                     }
@@ -604,6 +612,9 @@ fn send(sender: &ResponseSender, response: Response) {
         (ResponseSender::Mutable(s), Response::Mutable(r)) => {
             let _ = s.send(r);
         }
+        (ResponseSender::MutableDetailed { values, .. }, Response::Mutable(r)) => {
+            let _ = values.send(r);
+        }
         (ResponseSender::Immutable(s), Response::Immutable(r)) => {
             let _ = s.send(r);
         }
@@ -630,6 +641,10 @@ pub enum ResponseSender {
     ClosestNodes(Sender<Box<[Node]>>),
     Peers(Sender<Vec<SocketAddrV4>>),
     Mutable(Sender<MutableItem>),
+    MutableDetailed {
+        values: Sender<MutableItem>,
+        outcome: Sender<GetMutableOutcome>,
+    },
     Immutable(Sender<Box<[u8]>>),
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ pub use rpc::{
     config::Config,
     messages::{MessageType, PutRequestSpecific, RequestSpecific},
     server::{RequestFilter, ServerSettings, MAX_INFO_HASHES, MAX_PEERS, MAX_VALUES},
-    ClosestNodes, PutOutcome, DEFAULT_BOOTSTRAP_NODES, DEFAULT_REQUEST_TIMEOUT,
+    ClosestNodes, GetMutableOutcome, PutOutcome, DEFAULT_BOOTSTRAP_NODES, DEFAULT_REQUEST_TIMEOUT,
 };
 
 pub use ed25519_dalek::SigningKey;

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -35,7 +35,7 @@ use socket::KrpcSocket;
 pub use crate::common::messages;
 pub use closest_nodes::ClosestNodes;
 pub use info::Info;
-pub use iterative_query::GetRequestSpecific;
+pub use iterative_query::{GetMutableOutcome, GetRequestSpecific};
 pub use put_query::{ConcurrencyError, PutError, PutOutcome, PutQueryError};
 pub use socket::DEFAULT_REQUEST_TIMEOUT;
 
@@ -51,7 +51,7 @@ const REFRESH_TABLE_INTERVAL: Duration = Duration::from_secs(15 * 60);
 const PING_TABLE_INTERVAL: Duration = Duration::from_secs(5 * 60);
 
 /// Result of `tick_get_queries`: completed queries and whether self-findnode finished.
-type GetQueriesResult = (Vec<(Id, Box<[Node]>)>, bool);
+type GetQueriesResult = (Vec<GetQueryOutcome>, bool);
 
 const MAX_CACHED_ITERATIVE_QUERIES: usize = 1000;
 
@@ -521,7 +521,7 @@ impl Rpc {
     /// returning a final value for the associated target.
     ///
     /// Behavior:
-    /// - Ignores responses from read-only nodes.
+    /// - Ignores responses marked read-only, recording them as invalid responses.
     /// - If it matches an in-flight PutQuery, treats `Ping` as a storage ACK (success/error)
     ///   and stops further handling.
     /// - If it matches an in-flight iterative query:
@@ -544,6 +544,14 @@ impl Rpc {
     fn handle_response(&mut self, from: SocketAddrV4, message: Message) -> Option<(Id, Response)> {
         // If someone claims to be readonly, then let's not store anything even if they respond.
         if message.read_only {
+            if let Some(query) = self
+                .iterative_queries
+                .values_mut()
+                .find(|query| query.is_inflight_query_request(message.transaction_id))
+            {
+                query.record_invalid_response();
+            }
+
             return None;
         };
 
@@ -573,8 +581,15 @@ impl Rpc {
         if let Some(query) = self
             .iterative_queries
             .values_mut()
-            .find(|query| query.inflight(message.transaction_id))
+            .find(|query| query.is_inflight(message.transaction_id))
         {
+            let is_query_response = query.is_inflight_query_request(message.transaction_id);
+            let is_mutable_get_query_response = is_query_response
+                && matches!(
+                    &query.request.request_type,
+                    RequestTypeSpecific::GetValue(_)
+                );
+
             // KrpcSocket would not give us a response from the wrong address for the transaction_id
             should_add_node = true;
 
@@ -599,6 +614,10 @@ impl Rpc {
                     values,
                     ..
                 })) => {
+                    if is_mutable_get_query_response {
+                        query.record_invalid_response();
+                    }
+
                     let response = Response::Peers(values);
                     query.response(from, response.clone());
 
@@ -609,6 +628,10 @@ impl Rpc {
                         v, responder_id, ..
                     },
                 )) => {
+                    if is_mutable_get_query_response {
+                        query.record_invalid_response();
+                    }
+
                     if validate_immutable(&v, query.target()) {
                         let response = Response::Immutable(v);
                         query.response(from, response.clone());
@@ -644,12 +667,20 @@ impl Rpc {
 
                     match MutableItem::from_dht_message(query.target(), &k, v, seq, &sig, salt) {
                         Ok(item) => {
+                            if is_mutable_get_query_response {
+                                query.record_mutable_value();
+                            }
+
                             let response = Response::Mutable(item);
                             query.response(from, response.clone());
 
                             return Some((target, response));
                         }
                         Err(error) => {
+                            if is_mutable_get_query_response {
+                                query.record_invalid_mutable_value();
+                            }
+
                             debug!(
                                 ?error,
                                 ?from,
@@ -665,6 +696,10 @@ impl Rpc {
                         seq, responder_id, ..
                     },
                 )) => {
+                    if is_mutable_get_query_response {
+                        query.record_no_more_recent();
+                    }
+
                     debug!(
                         target= ?query.target(),
                         salt= ?match query.request.request_type.clone() {
@@ -682,6 +717,10 @@ impl Rpc {
                     responder_id,
                     ..
                 })) => {
+                    if is_mutable_get_query_response {
+                        query.record_no_values();
+                    }
+
                     debug!(
                         target= ?query.target(),
                         salt= ?match query.request.request_type.clone() {
@@ -695,6 +734,10 @@ impl Rpc {
                     );
                 }
                 MessageType::Error(error) => {
+                    if is_mutable_get_query_response {
+                        query.record_krpc_error();
+                    }
+
                     debug!(?error, ?from_version, "Get query got error response");
                 }
                 // Ping response is already handled in add_node()
@@ -702,7 +745,11 @@ impl Rpc {
                 // Requests are handled elsewhere
                 MessageType::Response(ResponseSpecific::Ping(_))
                 | MessageType::Response(ResponseSpecific::FindNode(_))
-                | MessageType::Request(_) => {}
+                | MessageType::Request(_) => {
+                    if is_mutable_get_query_response {
+                        query.record_invalid_response();
+                    }
+                }
             };
         };
 
@@ -981,7 +1028,15 @@ impl Rpc {
                     .into_boxed_slice()
             };
 
-            done_get_queries.push((*id, closest_nodes));
+            done_get_queries.push(GetQueryOutcome {
+                id: *id,
+                closest_nodes,
+                mutable_outcome: matches!(
+                    query.request.request_type,
+                    RequestTypeSpecific::GetValue(_)
+                )
+                .then(|| query.mutable_outcome()),
+            });
         }
 
         (done_get_queries, finished_self_findnode)
@@ -990,25 +1045,25 @@ impl Rpc {
     /// Remove completed GET and PUT queries from internal state.
     fn cleanup_done_queries(
         &mut self,
-        done_get: &[(Id, Box<[Node]>)],
+        done_get: &[GetQueryOutcome],
         done_put: &mut Vec<(Id, Result<PutOutcome, PutError>)>,
     ) {
         // Has to happen _before_ `self.socket.recv_from()`.
-        for (id, closest_nodes) in done_get {
-            let query = match self.iterative_queries.remove(id) {
+        for done in done_get {
+            let query = match self.iterative_queries.remove(&done.id) {
                 Some(query) => query,
                 None => continue,
             };
 
             self.update_address_votes_from_iterative_query(&query);
-            self.cache_iterative_query(&query, closest_nodes);
+            self.cache_iterative_query(&query, &done.closest_nodes);
 
             // Only for get queries, not find node.
             if matches!(query.request.request_type, RequestTypeSpecific::FindNode(_)) {
                 continue;
             }
 
-            let put_query = match self.put_queries.get_mut(id) {
+            let put_query = match self.put_queries.get_mut(&done.id) {
                 Some(put_query) => put_query,
                 None => continue,
             };
@@ -1017,8 +1072,8 @@ impl Rpc {
                 continue;
             }
 
-            if let Err(error) = put_query.start(&mut self.socket, closest_nodes) {
-                done_put.push((*id, Err(error)))
+            if let Err(error) = put_query.start(&mut self.socket, &done.closest_nodes) {
+                done_put.push((done.id, Err(error)))
             }
         }
 
@@ -1066,9 +1121,20 @@ struct CachedIterativeQuery {
 /// done PUT, GET, and FIND_NODE queries, as well as any
 /// incoming value response for any GET query.
 #[derive(Debug, Clone)]
+/// Completed GET/FIND_NODE query details returned from [Rpc::tick].
+pub struct GetQueryOutcome {
+    /// Query target id.
+    pub id: Id,
+    /// Closest responding nodes discovered by the query.
+    pub closest_nodes: Box<[Node]>,
+    /// Mutable GET diagnostics, present for GET value queries.
+    pub mutable_outcome: Option<GetMutableOutcome>,
+}
+
+#[derive(Debug, Clone)]
 pub struct RpcTickReport {
     /// All the [Id]s of the done [Rpc::get] queries.
-    pub done_get_queries: Vec<(Id, Box<[Node]>)>,
+    pub done_get_queries: Vec<GetQueryOutcome>,
     /// All the [Id]s of the done [Rpc::put] queries,
     /// and either the successful [PutOutcome] or a [PutError].
     pub done_put_queries: Vec<(Id, Result<PutOutcome, PutError>)>,
@@ -1102,8 +1168,9 @@ pub(crate) fn to_socket_address<T: ToSocketAddrs>(bootstrap: &[T]) -> Vec<Socket
 
 #[cfg(test)]
 mod tests {
-    use std::net::Ipv4Addr;
+    use std::net::{Ipv4Addr, SocketAddrV4};
 
+    use crate::common::FindNodeResponseArguments;
     use ed25519_dalek::SigningKey;
 
     use super::*;
@@ -1140,5 +1207,55 @@ mod tests {
             .unwrap();
 
         assert!(responses.is_empty());
+    }
+
+    #[test]
+    fn mutable_get_counts_wrong_primary_response_as_invalid() {
+        let mut rpc = Rpc::new(config::Config {
+            bootstrap: Some(vec![]),
+            bind_address: Some(Ipv4Addr::LOCALHOST),
+            ..Default::default()
+        })
+        .unwrap();
+
+        let target = Id::random();
+        let responder = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 42_000);
+
+        rpc.get(
+            GetRequestSpecific::GetValue(GetValueRequestArguments {
+                target,
+                seq: None,
+                salt: None,
+            }),
+            Some(&[responder]),
+        );
+
+        let response = rpc.handle_response(
+            responder,
+            Message {
+                transaction_id: 0,
+                message_type: MessageType::Response(ResponseSpecific::FindNode(
+                    FindNodeResponseArguments {
+                        responder_id: Id::random(),
+                        nodes: Vec::new().into_boxed_slice(),
+                    },
+                )),
+                version: None,
+                read_only: false,
+                requester_ip: None,
+            },
+        );
+
+        let outcome = rpc
+            .iterative_queries
+            .get(&target)
+            .expect("mutable GET query should still be active")
+            .mutable_outcome();
+
+        assert!(response.is_none());
+        assert_eq!(outcome.valid_responses(), 0);
+        assert_eq!(outcome.invalid_responses, 1);
+        assert_eq!(outcome.responded(), 1);
+        assert_eq!(outcome.timed_out(), 0);
     }
 }

--- a/src/rpc/iterative_query.rs
+++ b/src/rpc/iterative_query.rs
@@ -13,6 +13,71 @@ use crate::{
     rpc::Response,
 };
 
+/// Aggregate diagnostics for a mutable GET query.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct GetMutableOutcome {
+    /// Number of unique DHT nodes queried.
+    pub queried: u32,
+    /// Number of valid mutable values returned.
+    pub values: u32,
+    /// Number of `NoValues` responses returned.
+    pub no_values: u32,
+    /// Number of `NoMoreRecentValue` responses returned.
+    pub no_more_recent: u32,
+    /// Number of mutable value responses that failed validation.
+    pub invalid_values: u32,
+    /// Number of invalid response shapes returned.
+    pub invalid_responses: u32,
+    /// Number of KRPC error responses returned.
+    pub krpc_errors: u32,
+}
+
+impl GetMutableOutcome {
+    /// Return the number of nodes that returned a GET response before timing out.
+    pub fn responded(&self) -> u32 {
+        self.valid_responses() + self.invalid_values + self.invalid_responses + self.krpc_errors
+    }
+
+    /// Return the number of nodes that returned a valid GET response.
+    pub fn valid_responses(&self) -> u32 {
+        self.values + self.no_values + self.no_more_recent
+    }
+
+    /// Return the number of queried nodes that did not return a GET response before timeout.
+    pub fn timed_out(&self) -> u32 {
+        self.queried.saturating_sub(self.responded())
+    }
+
+    fn record_value(&mut self) {
+        self.values += 1;
+    }
+
+    fn record_no_values(&mut self) {
+        self.no_values += 1;
+    }
+
+    fn record_no_more_recent(&mut self) {
+        self.no_more_recent += 1;
+    }
+
+    fn record_invalid_value(&mut self) {
+        self.invalid_values += 1;
+    }
+
+    fn record_invalid_response(&mut self) {
+        self.invalid_responses += 1;
+    }
+
+    fn record_krpc_error(&mut self) {
+        self.krpc_errors += 1;
+    }
+
+    fn finish(mut self, queried: u32) -> Self {
+        self.queried = queried;
+        self
+    }
+}
+
 /// An iterative process of concurrently sending a request to the closest known nodes to
 /// the target, updating the routing table with closer nodes discovered in the responses, and
 /// repeating this process until no closer nodes (that aren't already queried) are found.
@@ -22,8 +87,10 @@ pub(crate) struct IterativeQuery {
     closest: ClosestNodes,
     responders: ClosestNodes,
     inflight_requests: Vec<u32>,
+    query_requests: Vec<u32>,
     visited: HashSet<SocketAddrV4>,
     responses: Vec<Response>,
+    mutable_outcome: GetMutableOutcome,
     public_address_votes: HashMap<SocketAddrV4, u16>,
 }
 
@@ -64,9 +131,11 @@ impl IterativeQuery {
             responders: ClosestNodes::new(target),
 
             inflight_requests: Vec::new(),
+            query_requests: Vec::new(),
             visited: HashSet::new(),
 
             responses: Vec::new(),
+            mutable_outcome: GetMutableOutcome::default(),
 
             public_address_votes: HashMap::new(),
         }
@@ -90,6 +159,12 @@ impl IterativeQuery {
 
     pub fn responses(&self) -> &[Response] {
         &self.responses
+    }
+
+    pub fn mutable_outcome(&self) -> GetMutableOutcome {
+        self.mutable_outcome
+            .clone()
+            .finish(self.visited.len() as u32)
     }
 
     pub fn best_address(&self) -> Option<SocketAddrV4> {
@@ -132,6 +207,7 @@ impl IterativeQuery {
     pub fn visit(&mut self, socket: &mut KrpcSocket, address: SocketAddrV4) {
         let tid = socket.request(address, self.request.clone());
         self.inflight_requests.push(tid);
+        self.query_requests.push(tid);
 
         let tid = socket.request(
             address,
@@ -146,8 +222,13 @@ impl IterativeQuery {
     }
 
     /// Return true if a response (by transaction_id) is expected by this query.
-    pub fn inflight(&self, tid: u32) -> bool {
+    pub fn is_inflight(&self, tid: u32) -> bool {
         self.inflight_requests.contains(&tid)
+    }
+
+    /// Return true if the transaction belongs to the primary query request, not the liveness ping.
+    pub fn is_inflight_query_request(&self, tid: u32) -> bool {
+        self.query_requests.contains(&tid)
     }
 
     /// Add a node that responded with a token as a probable storage node.
@@ -162,6 +243,30 @@ impl IterativeQuery {
         debug!(?target, ?response, ?from, "Query got response");
 
         self.responses.push(response.to_owned());
+    }
+
+    pub fn record_mutable_value(&mut self) {
+        self.mutable_outcome.record_value();
+    }
+
+    pub fn record_no_values(&mut self) {
+        self.mutable_outcome.record_no_values();
+    }
+
+    pub fn record_no_more_recent(&mut self) {
+        self.mutable_outcome.record_no_more_recent();
+    }
+
+    pub fn record_invalid_response(&mut self) {
+        self.mutable_outcome.record_invalid_response();
+    }
+
+    pub fn record_krpc_error(&mut self) {
+        self.mutable_outcome.record_krpc_error();
+    }
+
+    pub fn record_invalid_mutable_value(&mut self) {
+        self.mutable_outcome.record_invalid_value();
     }
 
     /// Query closest nodes for this query's target and message.


### PR DESCRIPTION
Add `get_mutable_detailed` to return mutable values as a stream
together with a final `GetMutableOutcome` report.

Track queried, responded, timed out, empty, stale, invalid, read-only,
and error responses so callers can diagnose whether missing mutable data
comes from DHT reachability, validation failures, or normal no-value
responses.
