### PR TITLE
chore: v8.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to mainline dht will be documented in this file.
 
+## [8.0.0](https://github.com/pubky/mainline/compare/v7.0.0...v8.0.0) - 2026-08-04
+
+### Fixed
+
+- Reject malformed mutable PUT requests that omit the required sequence number
+  or signature, and reject immutable PUT requests that include mutable-only
+  fields.
+- Validate that a mutable item's target matches the SHA-1 hash derived from its
+  public key and salt.
+
+### Changed
+
+- **BREAKING**: Add `MutableError::InvalidMutableTarget`; `MutableItem` no
+  longer implements `From<PutMutableRequestArguments>`.
+
 ## [7.0.0](https://github.com/pubky/mainline/compare/v6.2.0...v7.0.0) - 2026-06-08
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mainline"
-version = "7.0.0"
+version = "8.0.0"
 authors = [
     "nuh.dev",
     "SeverinAlexB <severin@synonym.to>",


### PR DESCRIPTION
### Fixed

- Reject malformed mutable PUT requests that omit the required sequence number
  or signature, and reject immutable PUT requests that include mutable-only
  fields.
- Validate that a mutable item's target matches the SHA-1 hash derived from its
  public key and salt.

### Changed

- **BREAKING**: Add `MutableError::InvalidMutableTarget`; `MutableItem` no
  longer implements `From<PutMutableRequestArguments>`.
