### PR TITLE
build(mainline-next): add unpublished workspace crate

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -58,7 +58,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Lint with Clippy
-        run: cargo clippy --workspace --all-features --bins --tests -- -D warnings
+        run: cargo clippy --workspace --all-features --lib --bins --tests -- -D warnings
 
   deny:
     name: Cargo Deny

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,7 @@
+[workspace]
+members = ["mainline-next"]
+resolver = "2"
+
 [package]
 name = "mainline"
 version = "8.0.0"

--- a/mainline-next/Cargo.toml
+++ b/mainline-next/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "mainline-next"
+version = "0.0.0"
+edition = "2021"
+rust-version = "1.85"
+publish = false
+license = "MIT"
+description = "Development crate for the Mainline DHT refactor"

--- a/mainline-next/README.md
+++ b/mainline-next/README.md
@@ -1,4 +1,23 @@
-# Two-Level DHT Item API Proposal
+# Mainline Next
+
+Unpublished workspace crate for the Mainline DHT refactor, developed alongside
+the existing `mainline` crate. Requires Rust 1.85 or newer. Currently only the
+crate setup is implemented; there is no runtime or public API yet.
+
+## Development
+
+Run from the repository root:
+
+```sh
+cargo check -p mainline-next
+cargo test -p mainline-next
+cargo +1.85.0 check -p mainline-next
+cargo fmt --all -- --check
+```
+
+CI checks, builds, tests, lints, and documents both workspace crates.
+
+## Design
 
 This proposal separates low-level DHT event streams from high-level estimates
 and conclusions derived from those streams. The roadmap describes the staged

--- a/mainline-next/src/lib.rs
+++ b/mainline-next/src/lib.rs
@@ -1,0 +1,5 @@
+//! Development crate for the Mainline DHT refactor.
+//!
+//! This unpublished crate is developed alongside `mainline`. It currently
+//! contains no runtime or public API; see the repository's `mainline-next/docs`
+//! directory for the design and implementation plan.


### PR DESCRIPTION
Set up a dependency-free library with Rust 1.85 support.
Include it in workspace CI and document development commands.
