### PR TITLE
feat(mainline-next): add Serde KRPC wire types

### DIFF
--- a/mainline-next/Cargo.toml
+++ b/mainline-next/Cargo.toml
@@ -6,3 +6,7 @@ rust-version = "1.85"
 publish = false
 license = "MIT"
 description = "Development crate for the Mainline DHT refactor"
+
+[dependencies]
+serde = { version = "1", features = ["derive"], default-features = false }
+serde_bencode = { version = "0.2", default-features = false }

--- a/mainline-next/docs/wire-comparison.md
+++ b/mainline-next/docs/wire-comparison.md
@@ -1,0 +1,102 @@
+# Wire implementation comparison
+
+All differences below are accepted. Neither implementation is uniformly stricter.
+The existing [message decoder](../../src/common/messages.rs) includes domain
+conversions; the new [wire types](../src/wire/mod.rs) cover Serde representation
+only, with validation responsibilities described below.
+
+## Accepted inputs
+
+| Area | Existing implementation | New wire types |
+|---|---|---|
+| Transaction ID and version | Exactly four bytes each | Arbitrary byte-string lengths |
+| Query `ro` | Any `i32`; positive means true | `0`, `1`, or absence |
+| `implied_port` | `0..=255`; nonzero means true | `0`, `1`, or absence |
+| Arguments | Dictionaries or positional lists | Dictionaries only |
+| Byte-string fields | Also coerces integer lists through `serde_bytes` | Byte strings only |
+| PUT `target` | Required and emitted | Ignored on input; omitted on output |
+| PUT value | Byte strings, including integer-list coercion | Any bencoded value |
+| Mutable PUT fields | Checks key/signature lengths and field combinations | Checks lengths; preserves independent fields |
+| Errors | `i32` code, UTF-8 description | `i64` code, binary description |
+
+Both require a transaction ID; version is optional. [BEP 5] uses an opaque
+transaction string and recommends a four-byte version. Accepting other version
+lengths is a compatibility choice. [BEP 43] defines `ro=1`; accepting `0` and
+rejecting other values are our parsing choices.
+
+The dictionary, byte-string, and `implied_port` representations match [BEP 5].
+[BEP 44] permits strings, integers, lists, and dictionaries as item values. Its
+PUT format omits `target`, which the receiver derives from the item; ignoring an
+extra incoming `target` is our compatibility choice. Consequently, the existing
+decoder rejects PUTs emitted by the new types.
+
+Both enforce [BEP 44]'s 32-byte key and 64-byte signature lengths. The old
+conversion also requires `sig` and `seq` with `k`, and rejects `sig`, `seq`,
+`salt`, or `cas` without `k`. The new types defer those checks to the layer above.
+[BEP 5] errors are integer/string pairs, without an `i32` or UTF-8 restriction;
+[BEP 44] adds codes using that same format.
+
+Definitions: [existing wire types](../../src/common/messages/internal.rs),
+[new messages](../src/wire/message.rs), [queries](../src/wire/query.rs), and
+[flags](../src/wire/optional_bool.rs).
+
+## Response interpretation
+
+The old untagged enum tries variants in order and may discard fields when it
+falls back. The new [response structure](../src/wire/response.rs) preserves
+recognized fields and rejects malformed representations.
+
+| Input | Existing decoder | New wire types |
+|---|---|---|
+| `{id, nodes: 1}` | Falls back to Ping | Rejects: `nodes` must be a binary string ([BEP 5]) |
+| Duplicate `nodes` | Can fall back to Ping | Rejects under our parsing policy |
+| `{id, token, seq, v}` without `k` | Becomes NoMoreRecentValue, losing `v` | Preserves fields for later validation |
+| Integer item value | Can fall back to Ping, losing the value | Retains the integer, permitted by [BEP 44] |
+
+The old decoder still rejects some malformed contacts during conversion, such as
+a three-byte `nodes` string or a short peer address in a response with a token.
+The new types check every supplied contact against [BEP 5]'s six-byte peer and
+26-byte node encodings.
+
+Both accept ID-only replies and support `nodes` alongside `values`. ID-only
+replies are valid for ping, announce, and PUT, but are not complete GET replies.
+[BEP 44] permits conditional GET replies with `seq` but no `k`, `sig`, or `v`;
+this does not justify discarding a value actually received. Preserving fields
+avoids data loss without declaring every combination valid.
+
+## Encoding and metadata
+
+- **`ro`:** old code emits `0` or `1` on every message kind; new code emits only
+  `ro=1`, only on queries, matching [BEP 43].
+- **`implied_port`:** old code checks `is_some()`, incorrectly emitting `1` for
+  `Some(false)` and `0` for absence. New code omits false and emits `1` for true,
+  consistent with [BEP 5]'s optional flag.
+- **Field placement:** old code validates `ip` and `ro` on every message kind.
+  New queries ignore `ip`; responses/errors ignore `ro`, even when malformed.
+  [BEP 42] describes `ip` on responses/errors; [BEP 43] describes `ro` on queries.
+  Ignoring them elsewhere is our compatibility choice; neither BEP requires
+  rejection there.
+
+## Validation responsibilities
+
+The layer above the wire types will:
+
+- Check mutable PUT field combinations and salt/item sizes before acceptance.
+- Validate responses using the originating query and field-consistency rules.
+- Handle human-readable error descriptions; wire types preserve received bytes.
+
+The future codec will handle bounds, canonical bencoding, duplicate keys, and
+complete-input validation. Both decoders currently accept trailing bytes in the
+comparison cases and ignore unknown fields, including repeated unknown fields.
+Rejecting duplicate `nodes` is not general duplicate-key validation. These codec
+changes remain deferred; see [wire scope](wire.md#scope).
+
+## Verification
+
+Behavior was checked through source inspection and an isolated comparison
+program. This document also reflects the subsequent key/signature length checks.
+
+[BEP 5]: https://www.bittorrent.org/beps/bep_0005.html
+[BEP 42]: https://www.bittorrent.org/beps/bep_0042.html
+[BEP 43]: https://www.bittorrent.org/beps/bep_0043.html
+[BEP 44]: https://www.bittorrent.org/beps/bep_0044.html

--- a/mainline-next/docs/wire.md
+++ b/mainline-next/docs/wire.md
@@ -1,0 +1,49 @@
+# KRPC Wire Types
+
+[`src/wire/`](../src/wire/mod.rs) represents IPv4 KRPC messages independently of
+sockets and domain policy. Successful deserialization establishes field shapes,
+not whether a message is valid for a particular operation or safe to act on.
+
+## Design choices
+
+Custom byte and dictionary wrappers enforce bencoding representations that
+Serde convenience types do not: `serde_bytes` also accepts integer lists, and
+derived structs can accept positional lists. Binary strings remain opaque.
+
+Unknown fields are ignored for forward compatibility, including fields defined
+for another message kind. Recognized fields still undergo representation
+checks. The [implementation comparison](wire-comparison.md) records the accepted
+compatibility choices and distinguishes them from protocol requirements.
+
+Responses do not identify their originating query, so fields remain independent
+for query-aware validation. This preserves absent versus empty contents and
+avoids losing fields through variant fallback. Conditional BEP 44 GET replies
+may contain only a sequence, but any supplied value must still be retained.
+
+Mutable PUT fields remain independent; the layer above validates their
+combinations.
+
+## Scope
+
+The layer above must validate messages before they affect results, routing, or
+storage. Its responsibilities include:
+
+- Response requirements for the originating query, such as a token and nodes or
+  peers for `get_peers`.
+- Mutable-field consistency, salt/encoded-item sizes, signatures, target hashes,
+  and sequence/CAS rules. Fixed byte lengths do not establish cryptographic validity.
+- Domain conversions, ID/IP binding checks, outgoing read-only policy, and
+  human-readable error handling.
+
+Packet/nesting limits, complete-input validation, and general duplicate-key
+handling remain future codec work.
+
+**TODO, deferred:** validate canonical bencoding before conversion to `Value`.
+`serde_bencode` stores dictionaries in a `HashMap`, losing key order and
+overwriting duplicates. Re-encoding normalizes the data; it cannot validate the
+original encoding. [BEP 44](https://www.bittorrent.org/beps/bep_0044.html) requires
+rejecting invalid item bencoding, including unsorted keys, before accepting a PUT.
+
+The backend requires UTF-8 envelope field names, including ignored extensions;
+item dictionary keys and byte-string values may be binary. Revisit this
+restriction when choosing the final codec backend.

--- a/mainline-next/src/lib.rs
+++ b/mainline-next/src/lib.rs
@@ -1,5 +1,9 @@
 //! Development crate for the Mainline DHT refactor.
 //!
 //! This unpublished crate is developed alongside `mainline`. It currently
-//! contains no runtime or public API; see the repository's `mainline-next/docs`
-//! directory for the design and implementation plan.
+//! provides internal KRPC wire types, with no runtime or public
+//! API. See the repository's `mainline-next/docs` directory for the design.
+
+// The codec and reactor will consume these wire types in subsequent steps.
+#[allow(dead_code)]
+mod wire;

--- a/mainline-next/src/wire/byte_array.rs
+++ b/mainline-next/src/wire/byte_array.rs
@@ -1,0 +1,73 @@
+use std::fmt;
+
+use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
+
+/// A fixed-size binary string, without cryptographic validation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ByteArray<const N: usize>(pub [u8; N]);
+
+impl<const N: usize> Serialize for ByteArray<N> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_bytes(&self.0)
+    }
+}
+
+impl<'de, const N: usize> Deserialize<'de> for ByteArray<N> {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct BytesVisitor<const N: usize>;
+
+        impl<const N: usize> Visitor<'_> for BytesVisitor<N> {
+            type Value = ByteArray<N>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(formatter, "a {N}-byte string")
+            }
+
+            fn visit_bytes<E: serde::de::Error>(self, bytes: &[u8]) -> Result<Self::Value, E> {
+                bytes
+                    .try_into()
+                    .map(ByteArray)
+                    .map_err(|_error| E::invalid_length(bytes.len(), &self))
+            }
+        }
+
+        deserializer.deserialize_bytes(BytesVisitor::<N>)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_bencode::value::Value;
+
+    use super::*;
+
+    #[test]
+    fn encodes_bytes_and_requires_exact_length() {
+        fn check<const N: usize>() {
+            let bytes = ByteArray([255; N]);
+            let encoded = serde_bencode::to_bytes(&bytes).unwrap();
+            let prefix = format!("{N}:");
+            assert_eq!(&encoded[..prefix.len()], prefix.as_bytes());
+            assert_eq!(&encoded[prefix.len()..], &bytes.0);
+            assert_eq!(
+                serde_bencode::from_bytes::<ByteArray<N>>(&encoded).unwrap(),
+                bytes
+            );
+            for value in [
+                Value::Bytes(vec![]),
+                Value::Bytes(vec![0; N - 1]),
+                Value::Bytes(vec![0; N + 1]),
+                Value::List(vec![Value::Int(0); N]),
+            ] {
+                assert!(serde_bencode::from_bytes::<ByteArray<N>>(
+                    &serde_bencode::to_bytes(&value).unwrap()
+                )
+                .is_err());
+            }
+        }
+
+        check::<20>();
+        check::<32>();
+        check::<64>();
+    }
+}

--- a/mainline-next/src/wire/byte_string.rs
+++ b/mainline-next/src/wire/byte_string.rs
@@ -1,0 +1,72 @@
+use std::fmt;
+
+use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
+
+/// Accept binary strings only; byte-vector visitors may also accept integer lists.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ByteString(pub Vec<u8>);
+
+impl Serialize for ByteString {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_bytes(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for ByteString {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct BytesVisitor;
+
+        impl Visitor<'_> for BytesVisitor {
+            type Value = ByteString;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("a byte string")
+            }
+
+            fn visit_bytes<E: serde::de::Error>(self, bytes: &[u8]) -> Result<Self::Value, E> {
+                Ok(ByteString(bytes.to_vec()))
+            }
+
+            fn visit_byte_buf<E: serde::de::Error>(self, bytes: Vec<u8>) -> Result<Self::Value, E> {
+                Ok(ByteString(bytes))
+            }
+        }
+
+        deserializer.deserialize_byte_buf(BytesVisitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialization_reuses_owned_buffer() {
+        struct OwnedBytes(Vec<u8>);
+
+        impl<'de> Deserializer<'de> for OwnedBytes {
+            type Error = serde::de::value::Error;
+
+            fn deserialize_any<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+                visitor.visit_byte_buf(self.0)
+            }
+
+            serde::forward_to_deserialize_any! {
+                bool i8 i16 i32 i64 u8 u16 u32 u64 f32 f64 char str string bytes
+                byte_buf option unit unit_struct newtype_struct seq tuple
+                tuple_struct map struct enum identifier ignored_any
+            }
+        }
+
+        let bytes = vec![0, 255, 128];
+        let pointer = bytes.as_ptr();
+        let decoded = ByteString::deserialize(OwnedBytes(bytes)).unwrap();
+        assert_eq!(decoded.0, [0, 255, 128]);
+        assert_eq!(decoded.0.as_ptr(), pointer);
+    }
+
+    #[test]
+    fn byte_string_rejects_integer_lists() {
+        assert!(serde_bencode::from_bytes::<ByteString>(b"li1ei2ee").is_err());
+    }
+}

--- a/mainline-next/src/wire/compact_address.rs
+++ b/mainline-next/src/wire/compact_address.rs
@@ -1,0 +1,65 @@
+use std::net::{Ipv4Addr, SocketAddrV4};
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use super::ByteArray;
+
+/// IPv4 address and port encoded as six compact bytes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct CompactAddress(pub SocketAddrV4);
+
+impl CompactAddress {
+    pub(crate) fn to_bytes(self) -> [u8; 6] {
+        let mut bytes = [0; 6];
+        bytes[..4].copy_from_slice(&self.0.ip().octets());
+        bytes[4..].copy_from_slice(&self.0.port().to_be_bytes());
+        bytes
+    }
+
+    pub(crate) fn from_bytes([a, b, c, d, high, low]: [u8; 6]) -> Self {
+        Self(SocketAddrV4::new(
+            Ipv4Addr::new(a, b, c, d),
+            u16::from_be_bytes([high, low]),
+        ))
+    }
+}
+
+impl Serialize for CompactAddress {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_bytes(&self.to_bytes())
+    }
+}
+
+impl<'de> Deserialize<'de> for CompactAddress {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        ByteArray::<6>::deserialize(deserializer).map(|bytes| Self::from_bytes(bytes.0))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compact_address_uses_network_byte_order() {
+        let address = CompactAddress(SocketAddrV4::new(Ipv4Addr::new(1, 2, 3, 4), 6881));
+        let bytes = b"6:\x01\x02\x03\x04\x1a\xe1";
+        assert_eq!(serde_bencode::to_bytes(&address).unwrap(), bytes);
+        assert_eq!(
+            serde_bencode::from_bytes::<CompactAddress>(bytes).unwrap(),
+            address
+        );
+    }
+
+    #[test]
+    fn compact_address_requires_six_byte_string() {
+        for bytes in [
+            b"0:".as_slice(),
+            b"5:abcde",
+            b"7:abcdefg",
+            b"li1ei2ei3ei4ei5ei6ee",
+        ] {
+            assert!(serde_bencode::from_bytes::<CompactAddress>(bytes).is_err());
+        }
+    }
+}

--- a/mainline-next/src/wire/compact_nodes.rs
+++ b/mainline-next/src/wire/compact_nodes.rs
@@ -1,0 +1,124 @@
+use std::{fmt, net::SocketAddrV4};
+
+use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
+
+use super::{ByteArray, CompactAddress, Id};
+
+const CONTACT_BYTES: usize = 26;
+
+/// A node's advertised ID and address, without routing state or verification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct NodeContact {
+    pub id: Id,
+    pub address: SocketAddrV4,
+}
+
+/// Node contacts concatenated into one binary string, 26 bytes per contact.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CompactNodes(pub Vec<NodeContact>);
+
+impl Serialize for CompactNodes {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut bytes = Vec::with_capacity(self.0.len() * CONTACT_BYTES);
+        for contact in &self.0 {
+            bytes.extend_from_slice(&contact.id.0);
+            bytes.extend_from_slice(&CompactAddress(contact.address).to_bytes());
+        }
+        serializer.serialize_bytes(&bytes)
+    }
+}
+
+impl<'de> Deserialize<'de> for CompactNodes {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct NodesVisitor;
+
+        impl Visitor<'_> for NodesVisitor {
+            type Value = CompactNodes;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("a byte string of 26-byte IPv4 node contacts")
+            }
+
+            fn visit_bytes<E: serde::de::Error>(self, bytes: &[u8]) -> Result<Self::Value, E> {
+                let contacts = bytes.chunks_exact(CONTACT_BYTES);
+                if !contacts.remainder().is_empty() {
+                    return Err(E::invalid_length(bytes.len(), &self));
+                }
+                let nodes = contacts
+                    .map(|contact| {
+                        let mut id = [0; 20];
+                        id.copy_from_slice(&contact[..20]);
+                        let mut address = [0; 6];
+                        address.copy_from_slice(&contact[20..]);
+                        NodeContact {
+                            id: ByteArray(id),
+                            address: CompactAddress::from_bytes(address).0,
+                        }
+                    })
+                    .collect();
+                Ok(CompactNodes(nodes))
+            }
+        }
+
+        deserializer.deserialize_bytes(NodesVisitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::Ipv4Addr;
+
+    use serde_bencode::value::Value;
+
+    use super::*;
+
+    #[test]
+    fn concatenates_contacts_in_network_byte_order() {
+        let nodes = CompactNodes(vec![
+            NodeContact {
+                id: ByteArray(*b"abcdefghij0123456789"),
+                address: SocketAddrV4::new(Ipv4Addr::new(1, 2, 3, 4), 6881),
+            },
+            NodeContact {
+                id: ByteArray([255; 20]),
+                address: SocketAddrV4::new(Ipv4Addr::new(5, 6, 7, 8), 65535),
+            },
+        ]);
+        let mut expected = b"52:abcdefghij0123456789\x01\x02\x03\x04\x1a\xe1".to_vec();
+        expected.extend_from_slice(&[255; 20]);
+        expected.extend_from_slice(b"\x05\x06\x07\x08\xff\xff");
+        assert_eq!(serde_bencode::to_bytes(&nodes).unwrap(), expected);
+        assert_eq!(
+            serde_bencode::from_bytes::<CompactNodes>(&expected).unwrap(),
+            nodes
+        );
+    }
+
+    #[test]
+    fn empty_nodes_use_empty_string() {
+        assert_eq!(
+            serde_bencode::to_bytes(&CompactNodes(vec![])).unwrap(),
+            b"0:"
+        );
+        assert_eq!(
+            serde_bencode::from_bytes::<CompactNodes>(b"0:").unwrap(),
+            CompactNodes(vec![])
+        );
+    }
+
+    #[test]
+    fn rejects_partial_contacts_and_non_strings() {
+        for length in [1, 20, 25, 27, 51, 53] {
+            let bytes = serde_bencode::to_bytes(&Value::Bytes(vec![0; length])).unwrap();
+            assert!(serde_bencode::from_bytes::<CompactNodes>(&bytes).is_err());
+        }
+        for value in [
+            Value::Int(1),
+            Value::List(vec![]),
+            Value::List(vec![Value::Int(0); 26]),
+        ] {
+            let bytes = serde_bencode::to_bytes(&value).unwrap();
+            assert!(serde_bencode::from_bytes::<CompactNodes>(&bytes).is_err());
+        }
+    }
+}

--- a/mainline-next/src/wire/error_code.rs
+++ b/mainline-next/src/wire/error_code.rs
@@ -1,0 +1,21 @@
+use serde::{Deserialize, Serialize};
+
+/// A KRPC error code. Unknown codes are preserved.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub(crate) struct ErrorCode(pub i64);
+
+impl ErrorCode {
+    pub(crate) const GENERIC: Self = Self(201);
+    pub(crate) const SERVER: Self = Self(202);
+    pub(crate) const PROTOCOL: Self = Self(203);
+    pub(crate) const METHOD_UNKNOWN: Self = Self(204);
+
+    /// The bencoded item exceeds the accepted size.
+    pub(crate) const VALUE_TOO_LARGE: Self = Self(205);
+    pub(crate) const INVALID_SIGNATURE: Self = Self(206);
+    pub(crate) const SALT_TOO_LARGE: Self = Self(207);
+    /// The supplied CAS sequence does not match the stored sequence.
+    pub(crate) const CAS_MISMATCH: Self = Self(301);
+    pub(crate) const SEQUENCE_TOO_LOW: Self = Self(302);
+}

--- a/mainline-next/src/wire/id.rs
+++ b/mainline-next/src/wire/id.rs
@@ -1,0 +1,4 @@
+use super::ByteArray;
+
+/// A 20-byte node ID, lookup target, or info hash on the wire.
+pub(crate) type Id = ByteArray<20>;

--- a/mainline-next/src/wire/map.rs
+++ b/mainline-next/src/wire/map.rs
@@ -1,0 +1,31 @@
+use std::{fmt, marker::PhantomData};
+
+use serde::{
+    de::{value::MapAccessDeserializer, MapAccess, Visitor},
+    Deserialize, Deserializer, Serialize,
+};
+
+/// Serde structs also accept positional lists; KRPC arguments must be maps.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(transparent)]
+pub(crate) struct Map<T>(pub T);
+
+impl<'de, T: Deserialize<'de>> Deserialize<'de> for Map<T> {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct MapVisitor<T>(PhantomData<T>);
+
+        impl<'de, T: Deserialize<'de>> Visitor<'de> for MapVisitor<T> {
+            type Value = Map<T>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("an argument dictionary")
+            }
+
+            fn visit_map<A: MapAccess<'de>>(self, map: A) -> Result<Self::Value, A::Error> {
+                T::deserialize(MapAccessDeserializer::new(map)).map(Map)
+            }
+        }
+
+        deserializer.deserialize_map(MapVisitor(PhantomData))
+    }
+}

--- a/mainline-next/src/wire/message.rs
+++ b/mainline-next/src/wire/message.rs
@@ -1,0 +1,41 @@
+use serde::{Deserialize, Serialize};
+
+use super::{
+    ByteString, CompactAddress, ErrorCode, Map, OptionalBool, ResponseArguments, WireQuery,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct WireMessage {
+    #[serde(rename = "t")]
+    pub transaction_id: ByteString,
+    #[serde(rename = "v", skip_serializing_if = "Option::is_none")]
+    pub version: Option<ByteString>,
+    #[serde(flatten)]
+    pub kind: WireKind,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "y")]
+pub(crate) enum WireKind {
+    #[serde(rename = "q")]
+    Query {
+        #[serde(flatten)]
+        query: WireQuery,
+        #[serde(rename = "ro", default, skip_serializing_if = "OptionalBool::is_false")]
+        read_only: OptionalBool,
+    },
+    #[serde(rename = "r")]
+    Response {
+        #[serde(rename = "r")]
+        arguments: Map<ResponseArguments>,
+        #[serde(rename = "ip", skip_serializing_if = "Option::is_none")]
+        requester_address: Option<CompactAddress>,
+    },
+    #[serde(rename = "e")]
+    Error {
+        #[serde(rename = "e")]
+        error: (ErrorCode, ByteString),
+        #[serde(rename = "ip", skip_serializing_if = "Option::is_none")]
+        requester_address: Option<CompactAddress>,
+    },
+}

--- a/mainline-next/src/wire/mod.rs
+++ b/mainline-next/src/wire/mod.rs
@@ -1,0 +1,34 @@
+//! Serde representations of IPv4 KRPC messages.
+//!
+//! These types describe wire fields only. They do not apply routing, identity,
+//! item-validation, or outgoing client policy, or bound bencode parsing.
+//! Unknown fields are ignored; `y` and `q` select message and query kinds.
+
+mod byte_array;
+mod byte_string;
+mod compact_address;
+pub(crate) mod compact_nodes;
+mod error_code;
+mod id;
+mod map;
+mod message;
+mod optional_bool;
+pub(crate) mod query;
+pub(crate) mod response;
+
+pub(crate) use byte_array::ByteArray;
+pub(crate) use byte_string::ByteString;
+pub(crate) use compact_address::CompactAddress;
+pub(crate) use compact_nodes::CompactNodes;
+pub(crate) use error_code::ErrorCode;
+pub(crate) use id::Id;
+pub(crate) use map::Map;
+// Used outside this module once the codec is added.
+#[allow(unused_imports)]
+pub(crate) use message::{WireKind, WireMessage};
+pub(crate) use optional_bool::OptionalBool;
+pub(crate) use query::WireQuery;
+pub(crate) use response::ResponseArguments;
+
+#[cfg(test)]
+mod tests;

--- a/mainline-next/src/wire/optional_bool.rs
+++ b/mainline-next/src/wire/optional_bool.rs
@@ -1,0 +1,51 @@
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// An integer `0`/`1` flag. Use `#[serde(default)]` to treat absence as false.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct OptionalBool(pub bool);
+
+impl OptionalBool {
+    pub(crate) fn is_false(&self) -> bool {
+        !self.0
+    }
+}
+
+impl Serialize for OptionalBool {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_i64(i64::from(self.0))
+    }
+}
+
+impl<'de> Deserialize<'de> for OptionalBool {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        match i64::deserialize(deserializer)? {
+            0 => Ok(Self(false)),
+            1 => Ok(Self(true)),
+            _ => Err(serde::de::Error::custom("expected integer 0 or 1")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encodes_and_decodes_zero_and_one() {
+        for (value, bytes) in [(false, b"i0e"), (true, b"i1e")] {
+            let flag = OptionalBool(value);
+            assert_eq!(serde_bencode::to_bytes(&flag).unwrap(), bytes);
+            assert_eq!(
+                serde_bencode::from_bytes::<OptionalBool>(bytes).unwrap(),
+                flag
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_other_values() {
+        for bytes in [b"i-1e".as_slice(), b"i2e", b"1:1", b"le", b"de"] {
+            assert!(serde_bencode::from_bytes::<OptionalBool>(bytes).is_err());
+        }
+    }
+}

--- a/mainline-next/src/wire/query.rs
+++ b/mainline-next/src/wire/query.rs
@@ -1,0 +1,91 @@
+//! Command-specific query arguments, without domain conversions or item policy.
+
+use serde::{Deserialize, Serialize};
+use serde_bencode::value::Value;
+
+use super::{ByteArray, ByteString, Id, Map, OptionalBool};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "q", rename_all = "snake_case")]
+pub(crate) enum WireQuery {
+    Ping {
+        #[serde(rename = "a")]
+        arguments: Map<PingArguments>,
+    },
+    FindNode {
+        #[serde(rename = "a")]
+        arguments: Map<FindNodeArguments>,
+    },
+    GetPeers {
+        #[serde(rename = "a")]
+        arguments: Map<GetPeersArguments>,
+    },
+    AnnouncePeer {
+        #[serde(rename = "a")]
+        arguments: Map<AnnouncePeerArguments>,
+    },
+    Get {
+        #[serde(rename = "a")]
+        arguments: Map<GetArguments>,
+    },
+    Put {
+        #[serde(rename = "a")]
+        arguments: Map<PutArguments>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct PingArguments {
+    pub id: Id,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct FindNodeArguments {
+    pub id: Id,
+    pub target: Id,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct GetPeersArguments {
+    pub id: Id,
+    pub info_hash: Id,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct AnnouncePeerArguments {
+    pub id: Id,
+    pub info_hash: Id,
+    pub port: u16,
+    #[serde(default, skip_serializing_if = "OptionalBool::is_false")]
+    pub implied_port: OptionalBool,
+    pub token: ByteString,
+}
+
+/// BEP 44 lookup for either an immutable or mutable item.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct GetArguments {
+    pub id: Id,
+    pub target: Id,
+    /// Request the mutable value only if its sequence is greater than this.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub seq: Option<i64>,
+}
+
+/// BEP 44 store arguments. Mutable-field consistency is checked separately.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct PutArguments {
+    pub id: Id,
+    pub token: ByteString,
+    #[serde(rename = "v")]
+    pub value: Value,
+    #[serde(rename = "k", skip_serializing_if = "Option::is_none")]
+    pub key: Option<ByteArray<32>>,
+    #[serde(rename = "sig", skip_serializing_if = "Option::is_none")]
+    pub signature: Option<ByteArray<64>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub seq: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub salt: Option<ByteString>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cas: Option<i64>,
+}

--- a/mainline-next/src/wire/response.rs
+++ b/mainline-next/src/wire/response.rs
@@ -1,0 +1,25 @@
+use serde::{Deserialize, Serialize};
+use serde_bencode::value::Value;
+
+use super::{ByteArray, ByteString, CompactAddress, CompactNodes, Id};
+
+/// Response fields shared by BEP 5 and BEP 44. The query determines which are required.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ResponseArguments {
+    pub id: Id,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub token: Option<ByteString>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nodes: Option<CompactNodes>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub values: Option<Vec<CompactAddress>>,
+    #[serde(rename = "v", skip_serializing_if = "Option::is_none")]
+    pub value: Option<Value>,
+    #[serde(rename = "k", skip_serializing_if = "Option::is_none")]
+    pub key: Option<ByteArray<32>>,
+    #[serde(rename = "sig", skip_serializing_if = "Option::is_none")]
+    pub signature: Option<ByteArray<64>>,
+    /// May be returned without `k`, `sig`, or `v` for a conditional GET.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub seq: Option<i64>,
+}

--- a/mainline-next/src/wire/tests.rs
+++ b/mainline-next/src/wire/tests.rs
@@ -1,0 +1,533 @@
+use std::{
+    collections::HashMap,
+    net::{Ipv4Addr, SocketAddrV4},
+};
+
+use serde_bencode::value::Value;
+
+use super::{compact_nodes::NodeContact, query::*, *};
+
+mod bep44;
+
+const ID: Id = ByteArray(*b"abcdefghij0123456789");
+const TARGET: Id = ByteArray(*b"0123456789abcdefghij");
+const PING: &[u8] = b"d1:ad2:id20:abcdefghij0123456789e1:q4:ping1:t2:aa1:y1:qe";
+
+fn query(query: WireQuery) -> WireMessage {
+    WireMessage {
+        transaction_id: ByteString(b"aa".to_vec()),
+        version: None,
+        kind: WireKind::Query {
+            query,
+            read_only: OptionalBool(false),
+        },
+    }
+}
+
+fn ping() -> WireMessage {
+    query(WireQuery::Ping {
+        arguments: Map(PingArguments { id: ID }),
+    })
+}
+
+fn response_arguments() -> ResponseArguments {
+    ResponseArguments {
+        id: ID,
+        token: None,
+        nodes: None,
+        values: None,
+        value: None,
+        key: None,
+        signature: None,
+        seq: None,
+    }
+}
+
+fn response(arguments: ResponseArguments) -> WireMessage {
+    WireMessage {
+        transaction_id: ByteString(b"aa".to_vec()),
+        version: None,
+        kind: WireKind::Response {
+            arguments: Map(arguments),
+            requester_address: None,
+        },
+    }
+}
+
+fn assert_wire(message: &WireMessage, bytes: &[u8]) {
+    assert_eq!(serde_bencode::to_bytes(message).unwrap(), bytes);
+    assert_eq!(
+        serde_bencode::from_bytes::<WireMessage>(bytes).unwrap(),
+        *message
+    );
+}
+
+fn assert_roundtrip(message: &WireMessage) -> Value {
+    let bytes = serde_bencode::to_bytes(message).unwrap();
+    assert_eq!(
+        serde_bencode::from_bytes::<WireMessage>(&bytes).unwrap(),
+        *message
+    );
+    serde_bencode::from_bytes(&bytes).unwrap()
+}
+
+fn dictionary(value: &mut Value) -> &mut HashMap<Vec<u8>, Value> {
+    let Value::Dict(dictionary) = value else {
+        panic!("expected dictionary");
+    };
+    dictionary
+}
+
+fn argument_dictionary<'a>(value: &'a mut Value, key: &[u8]) -> &'a mut HashMap<Vec<u8>, Value> {
+    let arguments = dictionary(value)
+        .get_mut(key)
+        .expect("expected argument field");
+    dictionary(arguments)
+}
+
+fn decode(value: &Value) -> Result<WireMessage, serde_bencode::Error> {
+    serde_bencode::from_bytes(&serde_bencode::to_bytes(value).unwrap())
+}
+
+#[test]
+fn ping_matches_wire_example() {
+    assert_wire(&ping(), PING);
+}
+
+#[test]
+fn transaction_id_and_version_preserve_binary_strings() {
+    for transaction_id in [vec![], vec![0, 255, 128]] {
+        let mut message = ping();
+        message.transaction_id = ByteString(transaction_id);
+        message.version = Some(ByteString(vec![255, 0]));
+        assert_roundtrip(&message);
+    }
+}
+
+#[test]
+fn envelope_requires_transaction_id_and_kind() {
+    for field in [b"t", b"y"] {
+        let mut value = assert_roundtrip(&ping());
+        dictionary(&mut value).remove(field.as_slice());
+        assert!(decode(&value).is_err());
+    }
+    for bytes in [b"le".as_slice(), b"d1:t2:aa1:y1:xe", b"d1:ti1e1:y1:qe"] {
+        assert!(serde_bencode::from_bytes::<WireMessage>(bytes).is_err());
+    }
+}
+
+#[test]
+fn query_ignores_unknown_and_inapplicable_fields() {
+    let mut value = assert_roundtrip(&ping());
+    for field in [b"lol".as_slice(), b"r", b"e", b"ip"] {
+        dictionary(&mut value).insert(field.to_vec(), Value::Bytes(b"haha".to_vec()));
+    }
+    assert_eq!(decode(&value).unwrap(), ping());
+}
+
+#[test]
+fn ping_and_announce_peer_response_matches_wire_example() {
+    let message = response(ResponseArguments {
+        id: ByteArray(*b"mnopqrstuvwxyz123456"),
+        ..response_arguments()
+    });
+    let bytes = b"d1:rd2:id20:mnopqrstuvwxyz123456e1:t2:aa1:y1:re";
+    assert_wire(&message, bytes);
+}
+
+#[test]
+fn response_parses_compact_nodes() {
+    let contact = NodeContact {
+        id: TARGET,
+        address: SocketAddrV4::new(Ipv4Addr::new(1, 2, 3, 4), 6881),
+    };
+    for token in [None, Some(ByteString(vec![0, 255]))] {
+        let message = response(ResponseArguments {
+            nodes: Some(CompactNodes(vec![contact])),
+            token,
+            ..response_arguments()
+        });
+        let mut value = assert_roundtrip(&message);
+        let arguments = argument_dictionary(&mut value, b"r");
+        assert_eq!(
+            arguments.get(b"nodes".as_slice()),
+            Some(&Value::Bytes(
+                b"0123456789abcdefghij\x01\x02\x03\x04\x1a\xe1".to_vec()
+            ))
+        );
+    }
+}
+
+#[test]
+fn get_peers_response_matches_wire_example() {
+    let bytes = b"d1:rd2:id20:abcdefghij01234567895:token8:aoeusnth6:valuesl6:axje.u6:idhtnmee1:t2:aa1:y1:re";
+    let expected = response(ResponseArguments {
+        token: Some(ByteString(b"aoeusnth".to_vec())),
+        values: Some(vec![
+            CompactAddress(SocketAddrV4::new(Ipv4Addr::new(97, 120, 106, 101), 11893)),
+            CompactAddress(SocketAddrV4::new(Ipv4Addr::new(105, 100, 104, 116), 28269)),
+        ]),
+        ..response_arguments()
+    });
+    assert_wire(&expected, bytes);
+}
+
+#[test]
+fn response_preserves_absent_and_empty_fields() {
+    for present in [false, true] {
+        let mut value = assert_roundtrip(&response(ResponseArguments {
+            token: present.then(|| ByteString(vec![])),
+            nodes: present.then(|| CompactNodes(vec![])),
+            values: present.then(Vec::new),
+            ..response_arguments()
+        }));
+        let arguments = argument_dictionary(&mut value, b"r");
+        for field in [b"token".as_slice(), b"nodes", b"values"] {
+            assert_eq!(arguments.contains_key(field), present);
+        }
+    }
+}
+
+#[test]
+fn response_preserves_combined_nodes_and_peers() {
+    let contact = NodeContact {
+        id: TARGET,
+        address: SocketAddrV4::new(Ipv4Addr::new(1, 2, 3, 4), 6881),
+    };
+    assert_roundtrip(&response(ResponseArguments {
+        token: Some(ByteString(vec![])),
+        nodes: Some(CompactNodes(vec![contact])),
+        values: Some(vec![CompactAddress(contact.address)]),
+        ..response_arguments()
+    }));
+}
+
+#[test]
+fn response_requires_twenty_byte_id() {
+    let mut value = assert_roundtrip(&response(response_arguments()));
+    let arguments = argument_dictionary(&mut value, b"r");
+    arguments.remove(b"id".as_slice());
+    assert!(decode(&value).is_err());
+    for id in [
+        Value::Bytes(vec![0; 19]),
+        Value::Bytes(vec![0; 21]),
+        Value::List(vec![Value::Int(0); 20]),
+    ] {
+        let arguments = argument_dictionary(&mut value, b"r");
+        arguments.insert(b"id".to_vec(), id);
+        assert!(decode(&value).is_err());
+    }
+}
+
+#[test]
+fn response_rejects_malformed_known_fields() {
+    for (field, invalid) in [
+        ("token", Value::Int(1)),
+        ("token", Value::List(vec![Value::Int(1)])),
+        ("nodes", Value::Bytes(vec![0; 25])),
+        ("nodes", Value::List(vec![])),
+        ("values", Value::Bytes(vec![0; 6])),
+        ("values", Value::List(vec![Value::Bytes(vec![0; 5])])),
+        ("values", Value::List(vec![Value::Bytes(vec![0; 7])])),
+        (
+            "values",
+            Value::List(vec![Value::List(vec![Value::Int(0); 6])]),
+        ),
+    ] {
+        let mut value = assert_roundtrip(&response(response_arguments()));
+        let arguments = argument_dictionary(&mut value, b"r");
+        arguments.insert(field.as_bytes().to_vec(), invalid);
+        assert!(decode(&value).is_err(), "invalid {field}");
+    }
+}
+
+#[test]
+fn response_ignores_unknown_fields() {
+    let message = response(response_arguments());
+    let mut value = assert_roundtrip(&message);
+    let arguments = argument_dictionary(&mut value, b"r");
+    for key in [b"unknown".to_vec(), b"nodes6".to_vec(), vec![255]] {
+        arguments.insert(key, Value::Int(42));
+    }
+    assert_eq!(decode(&value).unwrap(), message);
+}
+
+#[test]
+fn response_requires_dictionary_arguments() {
+    for bytes in [b"d1:t2:aa1:y1:re".as_slice(), b"d1:rle1:t2:aa1:y1:re"] {
+        assert!(serde_bencode::from_bytes::<WireMessage>(bytes).is_err());
+    }
+    let mut value = assert_roundtrip(&response(response_arguments()));
+    dictionary(&mut value).insert(
+        b"r".to_vec(),
+        Value::List(vec![
+            Value::Bytes(ID.0.to_vec()),
+            Value::Bytes(vec![]),
+            Value::Bytes(vec![]),
+            Value::List(vec![]),
+            Value::Int(1),
+            Value::Bytes(vec![0; 32]),
+            Value::Bytes(vec![0; 64]),
+            Value::Int(1),
+        ]),
+    );
+    assert!(decode(&value).is_err());
+}
+
+#[test]
+fn error_matches_wire_example() {
+    let message = WireMessage {
+        transaction_id: ByteString(b"aa".to_vec()),
+        version: None,
+        kind: WireKind::Error {
+            error: (
+                ErrorCode::GENERIC,
+                ByteString(b"A Generic Error Ocurred".to_vec()),
+            ),
+            requester_address: None,
+        },
+    };
+    assert_wire(
+        &message,
+        b"d1:eli201e23:A Generic Error Ocurrede1:t2:aa1:y1:ee",
+    );
+}
+
+#[test]
+fn error_requires_code_and_description_pair() {
+    for bytes in [
+        b"d1:t2:aa1:y1:ee".as_slice(),
+        b"d1:ele1:t2:aa1:y1:ee",
+        b"d1:eli201ee1:t2:aa1:y1:ee",
+        b"d1:eli201e3:bad0:e1:t2:aa1:y1:ee",
+        b"d1:el3:badi201ee1:t2:aa1:y1:ee",
+    ] {
+        assert!(serde_bencode::from_bytes::<WireMessage>(bytes).is_err());
+    }
+}
+
+#[test]
+fn read_only_accepts_zero_and_one_and_omits_false() {
+    let mut value = assert_roundtrip(&ping());
+    assert!(!dictionary(&mut value).contains_key(b"ro".as_slice()));
+    for (encoded, expected) in [(0, false), (1, true)] {
+        dictionary(&mut value).insert(b"ro".to_vec(), Value::Int(encoded));
+        let message = decode(&value).unwrap();
+        let WireKind::Query { read_only, .. } = &message.kind else {
+            panic!("expected query");
+        };
+        assert_eq!(read_only.0, expected);
+        let mut serialized = assert_roundtrip(&message);
+        assert_eq!(
+            dictionary(&mut serialized).get(b"ro".as_slice()),
+            expected.then_some(&Value::Int(1))
+        );
+    }
+}
+
+#[test]
+fn response_and_error_preserve_requester_address_and_ignore_read_only() {
+    let address = CompactAddress(SocketAddrV4::new(Ipv4Addr::new(1, 2, 3, 4), 6881));
+    for kind in [
+        WireKind::Response {
+            arguments: Map(response_arguments()),
+            requester_address: Some(address),
+        },
+        WireKind::Error {
+            error: (ErrorCode::GENERIC, ByteString(vec![0, 255])),
+            requester_address: Some(address),
+        },
+    ] {
+        let message = WireMessage { kind, ..ping() };
+        let mut value = assert_roundtrip(&message);
+        assert!(!dictionary(&mut value).contains_key(b"ro".as_slice()));
+        dictionary(&mut value).insert(b"ro".to_vec(), Value::Bytes(b"ignored".to_vec()));
+        assert_eq!(decode(&value).unwrap(), message);
+        dictionary(&mut value).insert(b"ip".to_vec(), Value::Bytes(vec![0; 5]));
+        assert!(decode(&value).is_err());
+    }
+}
+
+#[test]
+fn query_requires_known_method_and_dictionary_arguments() {
+    for field in [b"q", b"a"] {
+        let mut value = assert_roundtrip(&ping());
+        dictionary(&mut value).remove(field.as_slice());
+        assert!(decode(&value).is_err());
+    }
+    let mut value = assert_roundtrip(&ping());
+    dictionary(&mut value).insert(b"q".to_vec(), Value::Bytes(b"unknown".to_vec()));
+    assert!(decode(&value).is_err());
+    let mut value = assert_roundtrip(&ping());
+    dictionary(&mut value).insert(
+        b"a".to_vec(),
+        Value::List(vec![Value::Bytes(ID.0.to_vec())]),
+    );
+    assert!(decode(&value).is_err());
+}
+
+#[test]
+fn query_commands_roundtrip_and_require_arguments() {
+    let cases = [
+        (
+            WireQuery::Ping {
+                arguments: Map(PingArguments { id: ID }),
+            },
+            "ping",
+            vec!["id"],
+        ),
+        (
+            WireQuery::FindNode {
+                arguments: Map(FindNodeArguments {
+                    id: ID,
+                    target: TARGET,
+                }),
+            },
+            "find_node",
+            vec!["id", "target"],
+        ),
+        (
+            WireQuery::GetPeers {
+                arguments: Map(GetPeersArguments {
+                    id: ID,
+                    info_hash: TARGET,
+                }),
+            },
+            "get_peers",
+            vec!["id", "info_hash"],
+        ),
+        (
+            WireQuery::AnnouncePeer {
+                arguments: Map(AnnouncePeerArguments {
+                    id: ID,
+                    info_hash: TARGET,
+                    port: 6881,
+                    implied_port: OptionalBool(true),
+                    token: ByteString(vec![0, 255]),
+                }),
+            },
+            "announce_peer",
+            vec!["id", "info_hash", "port", "token"],
+        ),
+        (
+            WireQuery::Get {
+                arguments: Map(GetArguments {
+                    id: ID,
+                    target: TARGET,
+                    seq: Some(42),
+                }),
+            },
+            "get",
+            vec!["id", "target"],
+        ),
+        (
+            WireQuery::Put {
+                arguments: Map(PutArguments {
+                    id: ID,
+                    token: ByteString(vec![]),
+                    value: Value::Bytes(b"item".to_vec()),
+                    key: None,
+                    signature: None,
+                    seq: None,
+                    salt: None,
+                    cas: None,
+                }),
+            },
+            "put",
+            vec!["id", "token", "v"],
+        ),
+    ];
+    for (command, method, required_fields) in cases {
+        let mut value = assert_roundtrip(&query(command));
+        assert_eq!(
+            dictionary(&mut value).get(b"q".as_slice()),
+            Some(&Value::Bytes(method.as_bytes().to_vec()))
+        );
+        for field in required_fields {
+            let mut missing = value.clone();
+            let arguments = argument_dictionary(&mut missing, b"a");
+            arguments.remove(field.as_bytes());
+            assert!(decode(&missing).is_err(), "{method} requires {field}");
+        }
+        let arguments = argument_dictionary(&mut value, b"a");
+        arguments.insert(b"id".to_vec(), Value::Bytes(vec![0; 19]));
+        assert!(decode(&value).is_err(), "{method} requires a 20-byte ID");
+    }
+}
+
+#[test]
+fn announce_peer_defaults_implied_port_to_false() {
+    let mut value = assert_roundtrip(&query(WireQuery::AnnouncePeer {
+        arguments: Map(AnnouncePeerArguments {
+            id: ID,
+            info_hash: TARGET,
+            port: 6881,
+            implied_port: OptionalBool(false),
+            token: ByteString(vec![]),
+        }),
+    }));
+    let arguments = argument_dictionary(&mut value, b"a");
+    arguments.remove(b"implied_port".as_slice());
+    let WireKind::Query {
+        query: WireQuery::AnnouncePeer { arguments },
+        ..
+    } = decode(&value).unwrap().kind
+    else {
+        panic!("expected announce_peer");
+    };
+    assert!(!arguments.0.implied_port.0);
+}
+
+#[test]
+fn announce_peer_rejects_out_of_range_ports() {
+    let mut value = assert_roundtrip(&query(WireQuery::AnnouncePeer {
+        arguments: Map(AnnouncePeerArguments {
+            id: ID,
+            info_hash: TARGET,
+            port: 6881,
+            implied_port: OptionalBool(false),
+            token: ByteString(vec![]),
+        }),
+    }));
+    for port in [-1, 65536] {
+        let arguments = argument_dictionary(&mut value, b"a");
+        arguments.insert(b"port".to_vec(), Value::Int(port));
+        assert!(decode(&value).is_err());
+    }
+}
+
+#[test]
+fn announce_peer_implied_port_accepts_zero_and_one_and_omits_false() {
+    for (implied_port, encoded) in [(false, 0), (true, 1)] {
+        let mut value = assert_roundtrip(&query(WireQuery::AnnouncePeer {
+            arguments: Map(AnnouncePeerArguments {
+                id: ID,
+                info_hash: TARGET,
+                port: 6881,
+                implied_port: OptionalBool(implied_port),
+                token: ByteString(vec![]),
+            }),
+        }));
+        let arguments = argument_dictionary(&mut value, b"a");
+        assert_eq!(
+            arguments.get(b"implied_port".as_slice()),
+            implied_port.then_some(&Value::Int(1))
+        );
+        arguments.insert(b"implied_port".to_vec(), Value::Int(encoded));
+        let message = decode(&value).unwrap();
+        let WireKind::Query {
+            query: WireQuery::AnnouncePeer { arguments },
+            ..
+        } = &message.kind
+        else {
+            panic!("expected announce_peer");
+        };
+        assert_eq!(arguments.0.implied_port.0, implied_port);
+        let mut serialized = assert_roundtrip(&message);
+        let arguments = argument_dictionary(&mut serialized, b"a");
+        assert_eq!(
+            arguments.get(b"implied_port".as_slice()),
+            implied_port.then_some(&Value::Int(1))
+        );
+    }
+}

--- a/mainline-next/src/wire/tests/bep44.rs
+++ b/mainline-next/src/wire/tests/bep44.rs
@@ -1,0 +1,285 @@
+use super::*;
+
+fn put_arguments() -> PutArguments {
+    PutArguments {
+        id: ID,
+        token: ByteString(b"tok".to_vec()),
+        value: Value::Bytes(b"Hello World!".to_vec()),
+        key: None,
+        signature: None,
+        seq: None,
+        salt: None,
+        cas: None,
+    }
+}
+
+#[test]
+fn get_matches_wire_examples() {
+    for (seq, bytes) in [
+        (None, b"d1:ad2:id20:abcdefghij01234567896:target20:0123456789abcdefghije1:q3:get1:t2:aa1:y1:qe".as_slice()),
+        (Some(42), b"d1:ad2:id20:abcdefghij01234567893:seqi42e6:target20:0123456789abcdefghije1:q3:get1:t2:aa1:y1:qe"),
+    ] {
+        assert_wire(&query(WireQuery::Get {
+            arguments: Map(GetArguments { id: ID, target: TARGET, seq }),
+        }), bytes);
+    }
+}
+
+#[test]
+fn get_omits_absent_sequence() {
+    let mut value = assert_roundtrip(&query(WireQuery::Get {
+        arguments: Map(GetArguments {
+            id: ID,
+            target: TARGET,
+            seq: None,
+        }),
+    }));
+    let arguments = argument_dictionary(&mut value, b"a");
+    assert!(!arguments.contains_key(b"seq".as_slice()));
+}
+
+#[test]
+fn immutable_put_matches_wire_example() {
+    assert_wire(
+        &query(WireQuery::Put {
+            arguments: Map(put_arguments()),
+        }),
+        b"d1:ad2:id20:abcdefghij01234567895:token3:tok1:v12:Hello World!e1:q3:put1:t2:aa1:y1:qe",
+    );
+}
+
+#[test]
+fn mutable_put_matches_wire_example() {
+    let key = ByteArray([255; 32]);
+    let signature = ByteArray([128; 64]);
+    let message = query(WireQuery::Put {
+        arguments: Map(PutArguments {
+            key: Some(key),
+            signature: Some(signature),
+            seq: Some(42),
+            salt: Some(ByteString(b"foobar".to_vec())),
+            cas: Some(41),
+            ..put_arguments()
+        }),
+    });
+    let expected = [
+        b"d1:ad3:casi41e2:id20:abcdefghij01234567891:k32:".as_slice(),
+        &key.0,
+        b"4:salt6:foobar3:seqi42e3:sig64:",
+        &signature.0,
+        b"5:token3:tok1:v12:Hello World!e1:q3:put1:t2:aa1:y1:qe",
+    ]
+    .concat();
+    assert_wire(&message, &expected);
+}
+
+#[test]
+fn put_preserves_values_and_optional_mutable_fields() {
+    for value in [
+        Value::Bytes(vec![0, 255]),
+        Value::Int(42),
+        Value::List(vec![Value::Int(1)]),
+        Value::Dict(HashMap::from([(vec![255], Value::Bytes(vec![]))])),
+    ] {
+        for mutable in [false, true] {
+            let mut encoded = assert_roundtrip(&query(WireQuery::Put {
+                arguments: Map(PutArguments {
+                    id: ID,
+                    token: ByteString(vec![]),
+                    value: value.clone(),
+                    key: mutable.then_some(ByteArray([1; 32])),
+                    signature: mutable.then_some(ByteArray([2; 64])),
+                    seq: mutable.then_some(42),
+                    salt: mutable.then(|| ByteString(vec![])),
+                    cas: mutable.then_some(41),
+                }),
+            }));
+            let arguments = argument_dictionary(&mut encoded, b"a");
+            for field in [b"k".as_slice(), b"sig", b"seq", b"salt", b"cas"] {
+                assert_eq!(arguments.contains_key(field), mutable);
+            }
+            assert!(!arguments.contains_key(b"target".as_slice()));
+        }
+    }
+}
+
+#[test]
+fn put_rejects_malformed_mutable_fields() {
+    let message = query(WireQuery::Put {
+        arguments: Map(put_arguments()),
+    });
+    for (field, invalid) in [
+        ("k", Value::Bytes(vec![])),
+        ("k", Value::Bytes(vec![0; 31])),
+        ("k", Value::Bytes(vec![0; 33])),
+        ("k", Value::List(vec![Value::Int(0); 32])),
+        ("sig", Value::Bytes(vec![])),
+        ("sig", Value::Bytes(vec![0; 63])),
+        ("sig", Value::Bytes(vec![0; 65])),
+        ("sig", Value::List(vec![Value::Int(0); 64])),
+        ("seq", Value::Bytes(b"42".to_vec())),
+        ("cas", Value::Bytes(b"41".to_vec())),
+        ("salt", Value::Int(1)),
+        ("salt", Value::List(vec![Value::Int(0)])),
+    ] {
+        let mut value = assert_roundtrip(&message);
+        argument_dictionary(&mut value, b"a").insert(field.as_bytes().to_vec(), invalid);
+        assert!(decode(&value).is_err(), "invalid {field}");
+    }
+}
+
+#[test]
+fn put_preserves_independent_mutable_fields() {
+    for arguments in [
+        PutArguments {
+            key: Some(ByteArray([0; 32])),
+            ..put_arguments()
+        },
+        PutArguments {
+            signature: Some(ByteArray([0; 64])),
+            ..put_arguments()
+        },
+        PutArguments {
+            seq: Some(-1),
+            ..put_arguments()
+        },
+        PutArguments {
+            cas: Some(i64::MAX),
+            ..put_arguments()
+        },
+        PutArguments {
+            salt: Some(ByteString(vec![255; 65])),
+            ..put_arguments()
+        },
+    ] {
+        assert_roundtrip(&query(WireQuery::Put {
+            arguments: Map(arguments),
+        }));
+    }
+}
+
+#[test]
+fn get_responses_match_wire_examples() {
+    for (value, seq, bytes) in [
+        (Some(Value::Bytes(b"Hello World!".to_vec())), None, b"d1:rd2:id20:abcdefghij01234567895:nodes0:5:token3:tok1:v12:Hello World!e1:t2:aa1:y1:re".as_slice()),
+        (None, None, b"d1:rd2:id20:abcdefghij01234567895:nodes0:5:token3:toke1:t2:aa1:y1:re"),
+        (None, Some(42), b"d1:rd2:id20:abcdefghij01234567895:nodes0:3:seqi42e5:token3:toke1:t2:aa1:y1:re"),
+    ] {
+        assert_wire(&response(ResponseArguments {
+            token: Some(ByteString(b"tok".to_vec())),
+            nodes: Some(CompactNodes(vec![])),
+            value,
+            seq,
+            ..response_arguments()
+        }), bytes);
+    }
+}
+
+#[test]
+fn mutable_get_response_matches_wire_example() {
+    let key = ByteArray([255; 32]);
+    let signature = ByteArray([128; 64]);
+    let message = response(ResponseArguments {
+        token: Some(ByteString(b"tok".to_vec())),
+        nodes: Some(CompactNodes(vec![])),
+        value: Some(Value::Bytes(b"Hello World!".to_vec())),
+        key: Some(key),
+        signature: Some(signature),
+        seq: Some(42),
+        ..response_arguments()
+    });
+    let expected = [
+        b"d1:rd2:id20:abcdefghij01234567891:k32:".as_slice(),
+        &key.0,
+        b"5:nodes0:3:seqi42e3:sig64:",
+        &signature.0,
+        b"5:token3:tok1:v12:Hello World!e1:t2:aa1:y1:re",
+    ]
+    .concat();
+    assert_wire(&message, &expected);
+}
+
+#[test]
+fn response_preserves_bep44_fields() {
+    for value in [
+        None,
+        Some(Value::Bytes(vec![0, 255])),
+        Some(Value::Int(42)),
+        Some(Value::List(vec![])),
+        Some(Value::Dict(HashMap::from([(vec![255], Value::Int(1))]))),
+    ] {
+        for mutable in [false, true] {
+            assert_roundtrip(&response(ResponseArguments {
+                token: Some(ByteString(vec![])),
+                value: value.clone(),
+                key: mutable.then_some(ByteArray([1; 32])),
+                signature: mutable.then_some(ByteArray([2; 64])),
+                seq: mutable.then_some(42),
+                ..response_arguments()
+            }));
+        }
+    }
+    assert_roundtrip(&response(ResponseArguments {
+        seq: Some(42),
+        ..response_arguments()
+    }));
+}
+
+#[test]
+fn response_rejects_malformed_mutable_fields() {
+    for (field, invalid) in [
+        ("k", Value::Bytes(vec![])),
+        ("k", Value::Bytes(vec![0; 31])),
+        ("k", Value::Bytes(vec![0; 33])),
+        ("k", Value::List(vec![Value::Int(0); 32])),
+        ("sig", Value::Bytes(vec![])),
+        ("sig", Value::Bytes(vec![0; 63])),
+        ("sig", Value::Bytes(vec![0; 65])),
+        ("sig", Value::List(vec![Value::Int(0); 64])),
+        ("seq", Value::Bytes(b"42".to_vec())),
+    ] {
+        let mut value = assert_roundtrip(&response(response_arguments()));
+        argument_dictionary(&mut value, b"r").insert(field.as_bytes().to_vec(), invalid);
+        assert!(decode(&value).is_err(), "invalid {field}");
+    }
+}
+
+#[test]
+fn put_response_matches_wire_example() {
+    assert_wire(
+        &response(response_arguments()),
+        b"d1:rd2:id20:abcdefghij0123456789e1:t2:aa1:y1:re",
+    );
+}
+
+#[test]
+fn errors_match_wire_examples() {
+    for (code, bytes) in [
+        (
+            ErrorCode::VALUE_TOO_LARGE,
+            b"d1:eli205e3:bade1:t2:aa1:y1:ee".as_slice(),
+        ),
+        (
+            ErrorCode::INVALID_SIGNATURE,
+            b"d1:eli206e3:bade1:t2:aa1:y1:ee",
+        ),
+        (ErrorCode::SALT_TOO_LARGE, b"d1:eli207e3:bade1:t2:aa1:y1:ee"),
+        (ErrorCode::CAS_MISMATCH, b"d1:eli301e3:bade1:t2:aa1:y1:ee"),
+        (
+            ErrorCode::SEQUENCE_TOO_LOW,
+            b"d1:eli302e3:bade1:t2:aa1:y1:ee",
+        ),
+        (ErrorCode(999), b"d1:eli999e3:bade1:t2:aa1:y1:ee"),
+    ] {
+        assert_wire(
+            &WireMessage {
+                kind: WireKind::Error {
+                    error: (code, ByteString(b"bad".to_vec())),
+                    requester_address: None,
+                },
+                ..ping()
+            },
+            bytes,
+        );
+    }
+}


### PR DESCRIPTION
Add IPv4 query, response, and error representations for BEPs 5,
42, 43, and 44, with strict byte strings and compact contacts.
